### PR TITLE
gh-ship: enrich issue at close — update criteria checkboxes and post PR narrative comment

### DIFF
--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -17,6 +17,9 @@ Creates a PR with context, squash-merges, closes the linked issue, exports the s
 - NEVER close the issue before the merge is confirmed
 - NEVER skip the Gist export — the session context on the PR is the audit trail
 - NEVER prompt the user during issue enrichment — derive checkboxes and close-out narrative from the Step 3 synthesis automatically; any prompt here breaks the single-keypress ship flow
+- NEVER chain Bash commands with `&&` or `;` — Claude Code's safety check fires on multi-command calls and interrupts mid-flow; run each as a separate Bash tool call
+- NEVER use `|` (pipe) in Bash tool calls — Claude Code stops execution on pipe; redirect to a temp file with `>` and read back with the Read tool
+- NEVER use `$()` command substitution — Claude Code's permission system prompts on `$()` during execution; use fixed paths under `.weld/tmp/` instead
 
 ## Workflow
 

--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -16,6 +16,7 @@ Creates a PR with context, squash-merges, closes the linked issue, exports the s
 - NEVER merge before confirming the PR was created successfully
 - NEVER close the issue before the merge is confirmed
 - NEVER skip the Gist export — the session context on the PR is the audit trail
+- NEVER prompt the user during issue enrichment — derive checkboxes and close-out narrative from the Step 3 synthesis automatically; any prompt here breaks the single-keypress ship flow
 
 ## Workflow
 

--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -106,11 +106,17 @@ If there is a linked issue, perform the following automatically — no user prom
 
 **a. Update acceptance criteria checkboxes**
 
-The issue body was fetched in Step 2. The commits and changed files were read in Step 3. For each `- [ ]` criterion in the issue body, determine whether the delivered changes satisfy it. Write the updated body with satisfied items marked `- [x]` to `.weld/tmp/issue-updated-body.md` using the Write tool:
+The issue body was fetched in Step 2. The commits and changed files were read in Step 3. For each `- [ ]` criterion in the issue body, determine whether the delivered changes satisfy it.
+
+If the issue body contains no `- [ ]` criteria, skip the edit step.
+
+Otherwise, write the updated body with satisfied items marked `- [x]` to `.weld/tmp/issue-updated-body.md` using the Write tool:
 
 ```bash
 gh issue edit <N> --body-file .weld/tmp/issue-updated-body.md
 ```
+
+If `gh issue edit` fails, diagnose the error and attempt to fix the underlying cause. Keep retrying until all reasonable fixes are exhausted, then surface the error and ask "(s)kip / (Q)uit?"
 
 ```bash
 rm .weld/tmp/issue-updated-body.md
@@ -133,6 +139,8 @@ Shipped in PR #<PR number>.
 ```bash
 gh issue comment <N> --body-file .weld/tmp/issue-close-comment.md
 ```
+
+If `gh issue comment` fails, diagnose the error and attempt to fix the underlying cause. Keep retrying until all reasonable fixes are exhausted, then surface the error and ask "(s)kip / (Q)uit?"
 
 ```bash
 rm .weld/tmp/issue-close-comment.md

--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -99,11 +99,48 @@ rm .weld/tmp/pr-body.md
 gh pr merge --squash --delete-branch
 ```
 
-### 6 — Close the issue
+### 6 — Enrich and close the issue
 
-If there is a linked issue:
+If there is a linked issue, perform the following automatically — no user prompts:
+
+**a. Update acceptance criteria checkboxes**
+
+The issue body was fetched in Step 2. The commits and changed files were read in Step 3. For each `- [ ]` criterion in the issue body, determine whether the delivered changes satisfy it. Write the updated body with satisfied items marked `- [x]` to `.weld/tmp/issue-updated-body.md` using the Write tool:
+
 ```bash
-gh issue close <N> --comment "Shipped in PR #<PR number>."
+gh issue edit <N> --body-file .weld/tmp/issue-updated-body.md
+```
+
+```bash
+rm .weld/tmp/issue-updated-body.md
+```
+
+**b. Post a close-out comment**
+
+Using the synthesis from Step 3, write the close-out comment to `.weld/tmp/issue-close-comment.md` using the Write tool:
+
+```markdown
+<One sentence describing what the PR delivered.>
+
+**What changed:**
+- <meaningful change 1 — what and why>
+- <meaningful change 2 — what and why>
+
+Shipped in PR #<PR number>.
+```
+
+```bash
+gh issue comment <N> --body-file .weld/tmp/issue-close-comment.md
+```
+
+```bash
+rm .weld/tmp/issue-close-comment.md
+```
+
+**c. Close the issue**
+
+```bash
+gh issue close <N>
 ```
 
 ### 7 — Export session to Gist and post to PR

--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-ship
-description: "GitHub shipping loop — wraps your finished work in a PR, merges it, exports the session as a Gist, and posts it as a comment. Does not implement code; you do the work, gh-ship handles everything GitHub. Invoke as /gh-ship to ship the current branch, or /gh-ship <issue-number> to target a specific issue. Use when you're ready to open a PR, merge, and export context."
+description: "GitHub shipping loop — wraps your finished work in a PR, merges it, exports the session as a Gist, and posts it as a comment. Enriches the linked issue before closing — updates acceptance criteria checkboxes and posts a close-out narrative comment automatically. Does not implement code; you do the work, gh-ship handles everything GitHub. Invoke as /gh-ship to ship the current branch, or /gh-ship <issue-number> to target a specific issue. Use when you're ready to open a PR, merge, and export context."
 ---
 
 # gh-ship

--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -118,7 +118,7 @@ Otherwise, write the updated body with satisfied items marked `- [x]` to `.weld/
 gh issue edit <N> --body-file .weld/tmp/issue-updated-body.md
 ```
 
-If `gh issue edit` fails, diagnose the error and attempt to fix the underlying cause. Keep retrying until all reasonable fixes are exhausted, then surface the error and ask "(s)kip / (Q)uit?"
+If `gh issue edit` fails, diagnose and fix: malformed body → rewrite the temp file with corrected content; auth error → verify with `gh auth status`; issue locked → note it and skip. Keep retrying until no further fixes apply, then surface the error and ask "(s)kip / (Q)uit?"
 
 ```bash
 rm .weld/tmp/issue-updated-body.md
@@ -142,7 +142,7 @@ Shipped in PR #<PR number>.
 gh issue comment <N> --body-file .weld/tmp/issue-close-comment.md
 ```
 
-If `gh issue comment` fails, diagnose the error and attempt to fix the underlying cause. Keep retrying until all reasonable fixes are exhausted, then surface the error and ask "(s)kip / (Q)uit?"
+If `gh issue comment` fails, diagnose and fix: malformed body → rewrite the temp file; auth error → verify with `gh auth status`; rate limit → wait and retry. Keep retrying until no further fixes apply, then surface the error and ask "(s)kip / (Q)uit?"
 
 ```bash
 rm .weld/tmp/issue-close-comment.md

--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -11,9 +11,9 @@ Creates a PR with context, squash-merges, closes the linked issue, exports the s
 
 ## NEVER
 
-- NEVER create a PR from main — validate the branch first; stop if on main
+- NEVER create a PR from main — `gh pr create` will succeed but target the wrong base, shipping unreleased work directly; create a feature branch first
 - NEVER pass a PR body with `#`-prefixed lines as an inline `--body` argument — write to `.weld/tmp/pr-body.md` and pass via `--body-file`
-- NEVER merge before confirming the PR was created successfully
+- NEVER merge before confirming the PR was created successfully — a failed `gh pr create` still exits 0 in some cases; verify the URL is present in the output before calling `gh pr merge`
 - NEVER close the issue before the merge is confirmed
 - NEVER skip the Gist export — the session context on the PR is the audit trail
 - NEVER prompt the user during issue enrichment — derive checkboxes and close-out narrative from the Step 3 synthesis automatically; any prompt here breaks the single-keypress ship flow

--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -106,7 +106,7 @@ If there is a linked issue, perform the following automatically — no user prom
 
 **a. Update acceptance criteria checkboxes**
 
-The issue body was fetched in Step 2. The commits and changed files were read in Step 3. For each `- [ ]` criterion in the issue body, determine whether the delivered changes satisfy it.
+The issue body was fetched in Step 2. The commits and changed files were read in Step 3. For each `- [ ]` criterion in the issue body, determine whether the delivered changes satisfy it. A criterion is satisfied if a commit message or changed file directly addresses the named behaviour; when ambiguous, leave it unchecked and note the uncertainty in the close-out comment.
 
 If the issue body contains no `- [ ]` criteria, skip the edit step.
 

--- a/.claude/skills/gh-ship/SKILL.md
+++ b/.claude/skills/gh-ship/SKILL.md
@@ -100,6 +100,8 @@ rm .weld/tmp/pr-body.md
 gh pr merge --squash --delete-branch
 ```
 
+If the merge fails, diagnose the cause (merge conflict → resolve and retry; branch protection → check required reviews or status checks; stale ref → sync branch and retry) and attempt to fix it. If unresolvable, surface the error and ask "(r)etry / (Q)uit?" — do not proceed to Step 6 until the merge is confirmed.
+
 ### 6 — Enrich and close the issue
 
 If there is a linked issue, perform the following automatically — no user prompts:


### PR DESCRIPTION
## Summary

Replaces gh-ship's bare `gh issue close --comment "Shipped in PR #N."` with a full issue enrichment loop: reads acceptance criteria, marks satisfied items `[x]` using a commit/file inference heuristic, posts a structured close-out comment (one sentence + bullet breakdown), then closes — all automatically, no user prompts. Also adds merge failure handling, scoped retry logic for gh CLI failures, and completes the NEVER rule set with WHYs and Claude Code bash anti-patterns.

## Changes

- Step 6 rewritten: checkbox update (skip if no criteria, self-healing retry with named diagnoses), close-out comment (narrative template), then close — in sequence, no prompts
- Criterion inference heuristic: satisfied if commit message or changed file directly addresses the named behaviour; ambiguous → leave unchecked and note in comment
- Merge failure handling added to Step 5: diagnose conflict/protection/stale-ref, fix and retry; escalate to user only if unresolvable
- NEVER rules completed: added WHY to create-from-main and merge-before-confirming; added &&/pipe/$() bash anti-patterns
- Description updated to surface the enrichment behaviour

## Test plan

- [ ] Run `/gh-ship` on a branch linked to an issue with `- [ ]` criteria — verify checkboxes are updated and close-out comment appears before the issue closes
- [ ] Run on an issue with no criteria — verify edit step is skipped and comment still posts

## Issue

Closes #3
