### PR TITLE
fix: rename gh-repo to gh-weld-repo to match naming convention

### DIFF
--- a/.claude/skills/gh-weld-repo/SKILL.md
+++ b/.claude/skills/gh-weld-repo/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: gh-repo
+name: gh-weld-repo
 description: Create a GitHub repo from a local directory via `gh repo create`. Inspects the current directory to infer repo name, language, topics, .gitignore template, and license — then interviews the user only for what it cannot infer, one question at a time. Shows a full confirm/edit/abort summary before acting. Pushes the local repo to the new remote on confirm. Use when: starting a project that needs a GitHub remote, pushing a local directory to GitHub for the first time. Triggers: "create a repo", "push to GitHub", "new GitHub repo", "initialize remote", "set up GitHub".
 compatibility: Requires git and gh CLI with authentication
 ---

--- a/.claude/skills/gh-weld-repo/SKILL.md
+++ b/.claude/skills/gh-weld-repo/SKILL.md
@@ -4,7 +4,7 @@ description: Create a GitHub repo from a local directory via `gh repo create`. I
 compatibility: Requires git and gh CLI with authentication
 ---
 
-# gh-repo
+# gh-weld-repo
 
 Create a GitHub repo from a local directory — infer what you can, ask for the rest, confirm before acting.
 


### PR DESCRIPTION
## Summary

Renames the `gh-repo` skill to `gh-weld-repo` to match the `gh-weld-*` naming convention used by all other skills in this repo. Updates the directory name, frontmatter `name` field, and H1 heading.

## Changes

- Renamed `.claude/skills/gh-repo/` → `.claude/skills/gh-weld-repo/`
- Updated `name: gh-repo` → `name: gh-weld-repo` in frontmatter
- Updated `# gh-repo` → `# gh-weld-repo` in body heading

## Test plan

- [ ] Confirm `.claude/skills/gh-weld-repo/SKILL.md` exists and `name:` field reads `gh-weld-repo`
- [ ] Confirm no remaining references to `gh-repo` in the repo
