### PR TITLE
Improve README value proposition with DIKW framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ These skills are opinionated about *workflow*, not implementation — they work 
 
 ![github-weld workflow diagram](diagram.svg)
 
+Git gives you data — diffs and commit hashes. GitHub gives you information — issues, PRs, linked references. `gh-weld` closes the gap toward knowledge: every merge carries a session export with the full reasoning trail, attached as a Gist and linked at the exact commit it belongs to. `git blame` a line, follow the PR, read why the decision was made and what was ruled out. That chain — from raw change to documented intent — is what turns a codebase into something a future agent or a new team member can actually learn from.
+
+The payoff is cumulative. Run this loop consistently and each issue becomes a structured artifact: acceptance criteria up front, a correctly-named branch, a merged PR, and a session transcript capturing the context that never survives in commit messages alone. Over time that's a mineable decision history — not just what the code does, but why it does it that way.
+
 ## Skills
 
 **[`/gh-weld-issue`](.claude/skills/gh-weld-issue/)** — Every piece of work needs an anchor before the first line of code. Creates one via a guided interview: duplicate check, structured body, and label discovery.


### PR DESCRIPTION
## Summary

Rewrote the post-diagram value section in README.md to be more concise and to make the DIKW (Data-Information-Knowledge-Wisdom) implication explicit. Reduced from three paragraphs to two, with the `git blame` → PR → session export reasoning chain described directly.

## Changes

- Replaced three-paragraph value section with two tighter paragraphs
- Added explicit DIKW framing (data → information → knowledge) as the conceptual spine
- Described the `git blame` → PR → session export chain as a mineable decision history

## Test plan

- [ ] README contains exactly two paragraphs between the diagram and the Skills section
- [ ] DIKW is named explicitly in the copy
- [ ] `git blame` chain is described

## Issue

Closes #22
