### PR TITLE
Add attribution footer to gh-weld-* output (issues, PRs, comments)

### DIFF
--- a/gh-weld-adopt/SKILL.md
+++ b/gh-weld-adopt/SKILL.md
@@ -173,6 +173,9 @@ Here's what I see you working on:
 ## Blockers
 
 None
+
+---
+*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
 ```
 
 Acceptance criteria must be verifiable. Reject vague entries like "works correctly" — they must name a command, visible change, or measurable value.

--- a/gh-weld-export/SKILL.md
+++ b/gh-weld-export/SKILL.md
@@ -65,6 +65,9 @@ Export the current session and post it to a GitHub PR or issue as a structured c
    ---
 
    [Full session context](<gist-url>)
+
+   ---
+   *Created with [gh-weld](https://github.com/WrathZA/github-weld)*
    ```
 
 8. Post the comment:

--- a/gh-weld-issue/SKILL.md
+++ b/gh-weld-issue/SKILL.md
@@ -100,7 +100,7 @@ Create a new GitHub issue through a brief HITL interview.
     ```bash
     gh issue create --title "<title>" --body-file .weld/tmp/issue-body.md --label "<labels>"
     ```
-    If no matching labels exist, omit `--label`.
+    If no matching labels exist, omit `--label`. If the command fails or produces no URL, surface the error and ask "(r)etry / (Q)uit?" — do not clean up until creation is confirmed.
 
 11. Clean up and output the issue URL:
     ```bash

--- a/gh-weld-issue/SKILL.md
+++ b/gh-weld-issue/SKILL.md
@@ -11,7 +11,7 @@ Create a new GitHub issue through a brief HITL interview.
 
 - NEVER pass a body with `#`-prefixed lines as an inline `--body` argument — write to `.weld/tmp/issue-body.md` with the Write tool and pass via `--body-file`; headers trigger Claude Code's security check on every execution
 - NEVER skip the duplicate check — a missed duplicate creates noise and confusion in the backlog
-- NEVER create issues for work you are about to implement in the same session — use `gh-weld-ship` instead; it creates the issue and links it to the branch automatically
+- NEVER create issues for work you are about to implement in the same session — the issue would be created and immediately closed with no meaningful history; use `gh-weld-ship` instead, which links the issue to the branch and closes it on merge
 - NEVER batch multiple ideas into one issue — one issue, one merge, one audit trail; batched issues can't be independently closed or reverted
 - NEVER chain Bash commands with `&&` or `;` — Claude Code's safety check fires on multi-command calls and interrupts mid-flow; run each as a separate Bash tool call
 - NEVER use `|` (pipe) in Bash tool calls — Claude Code stops execution on pipe; redirect to a temp file with `>` and read back with the Read tool. Note: `|` in markdown table syntax is unaffected.

--- a/gh-weld-issue/SKILL.md
+++ b/gh-weld-issue/SKILL.md
@@ -72,7 +72,7 @@ Create a new GitHub issue through a brief HITL interview.
    ```bash
    gh label list --json name
    ```
-   Match `bug`, `enhancement`, `feature`, `task`, `chore` against what exists. Note matching labels for step 9.
+   Match `bug`, `enhancement`, `feature`, `task`, `chore` against what exists. Note matching labels for step 9. If the command fails or returns empty, skip labels and note "no labels applied".
 
 9. Use the Write tool to write the issue body to `.weld/tmp/issue-body.md`:
 

--- a/gh-weld-issue/SKILL.md
+++ b/gh-weld-issue/SKILL.md
@@ -9,10 +9,16 @@ Create a new GitHub issue through a brief HITL interview.
 
 ## NEVER
 
-- NEVER pass a body with `#`-prefixed lines as an inline `--body` argument — write to `.weld/tmp/issue-body.md` with the Write tool and pass via `--body-file`
+- NEVER pass a body with `#`-prefixed lines as an inline `--body` argument — write to `.weld/tmp/issue-body.md` with the Write tool and pass via `--body-file`; headers trigger Claude Code's security check on every execution
 - NEVER skip the duplicate check — a missed duplicate creates noise and confusion in the backlog
 - NEVER create issues for work you are about to implement in the same session — use `gh-weld-ship` instead; it creates the issue and links it to the branch automatically
-- NEVER batch multiple ideas into one issue — one issue, one outcome
+- NEVER batch multiple ideas into one issue — one issue, one merge, one audit trail; batched issues can't be independently closed or reverted
+- NEVER chain Bash commands with `&&` or `;` — Claude Code's safety check fires on multi-command calls and interrupts mid-flow; run each as a separate Bash tool call
+- NEVER use `|` (pipe) in Bash tool calls — Claude Code stops execution on pipe; redirect to a temp file with `>` and read back with the Read tool. Note: `|` in markdown table syntax is unaffected.
+- NEVER use `$()` command substitution or backtick substitution (`` `cmd` ``) — Claude Code's permission system prompts on both during execution; use fixed paths under `.weld/tmp/` instead
+- NEVER use bash heredoc (`cat > file << 'EOF'`) for content with `#`-prefixed lines — headers trigger Claude Code's security check; use the Write tool instead
+- NEVER use `echo >` or `cat` to write file content — use the Write tool
+- NEVER use `find`, `grep`, or `cat` as Bash commands — use Glob, Grep, and Read tools instead
 
 ## Workflow
 
@@ -85,6 +91,9 @@ Create a new GitHub issue through a brief HITL interview.
    ## Blockers
 
    <"None" or "Depends on #N, #M">
+
+   ---
+   *Created with [gh-weld](https://github.com/WrathZA/github-weld)*
    ```
 
 10. Create the issue:

--- a/gh-weld-issue/SKILL.md
+++ b/gh-weld-issue/SKILL.md
@@ -26,9 +26,7 @@ Create a new GitHub issue through a brief HITL interview.
 
 1. Ask: "What are you trying to build or fix?"
 
-2. From the response, infer:
-   - A candidate title (specific, action-oriented: "Add X", "Fix Y when Z")
-   - Type: **bug** / **feature** / **task** / **chore**
+2. From the response, infer a candidate title (specific, action-oriented: "Add X", "Fix Y when Z") and type (**bug** / **feature** / **task** / **chore**) before asking. Ask only when genuinely ambiguous.
 
 3. Run a duplicate check using 2–4 key terms extracted from the inferred title:
    ```bash

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-weld-ship
-description: "GitHub shipping loop — wraps your finished work in a PR, merges it, exports the session as a Gist, and posts it as a comment. Enriches the linked issue before closing — updates acceptance criteria checkboxes and posts a close-out narrative comment automatically. Does not implement code; you do the work, gh-weld-ship handles everything GitHub. Use when you're ready to open a PR, merge, and export context."
+description: "GitHub shipping loop — wraps your finished work in a PR, squash-merges it, closes the linked issue, exports the session as a Gist, and posts it as a comment. Enriches the linked issue before closing — updates acceptance criteria checkboxes and posts a close-out narrative comment automatically. Does not implement code; you do the work, gh-weld-ship handles everything GitHub. Use when you're ready to open a PR, squash merge, close an issue, or export session context."
 disable-model-invocation: true
 when_to_use: "Use when done implementing, ready to ship, want to merge and close an issue, or when the user says 'I'm done' on a feature branch."
 ---

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -67,6 +67,8 @@ From the commit messages, changed files, and (if available) the issue body, synt
 - A bullet list of meaningful changes (what changed and why, not just filenames)
 - A minimal test plan (how to verify the main behaviour)
 
+A change bullet is meaningful if it names *what behaviour changed* and *why* — not just a filename. A test plan item is minimal if it describes the single most likely failure mode a reviewer would check.
+
 ### 4 — Create the PR
 
 Use the Write tool to write the PR body to `.weld/tmp/pr-body.md`:
@@ -88,6 +90,9 @@ Use the Write tool to write the PR body to `.weld/tmp/pr-body.md`:
 ## Issue
 
 Closes #<N>
+
+---
+*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
 ```
 
 If there is no linked issue, omit the `## Issue` section.

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -21,7 +21,8 @@ Creates a PR with context, squash-merges, closes the linked issue, exports the s
 - NEVER prompt the user during issue enrichment — derive checkboxes and close-out narrative from the Step 3 synthesis automatically; any prompt here breaks the single-keypress ship flow
 - NEVER chain Bash commands with `&&` or `;` — Claude Code's safety check fires on multi-command calls and interrupts mid-flow; run each as a separate Bash tool call
 - NEVER use `|` (pipe) in Bash tool calls — Claude Code stops execution on pipe; redirect to a temp file with `>` and read back with the Read tool. Note: `|` in markdown table syntax is unaffected.
-- NEVER use `$()` command substitution — Claude Code's permission system prompts on `$()` during execution; use fixed paths under `.weld/tmp/` instead
+- NEVER use `$()` command substitution or backtick substitution (`` `cmd` ``) — Claude Code's permission system prompts on both forms during execution; use fixed paths under `.weld/tmp/` instead
+- NEVER use `--no-verify` on git commits — bypasses pre-commit hooks that may enforce format or tests; a broken squash-merge to main blocks all future work
 - NEVER use bash heredoc (`cat > file << 'EOF'`) for content with `#`-prefixed lines — headers trigger Claude Code's security check on every execution; use the Write tool instead
 - NEVER use `echo >` or `cat` to write file content — use the Write tool; it avoids shell escaping issues and doesn't trigger permission checks
 - NEVER use `find`, `grep`, or `cat` as Bash commands — use Glob, Grep, and Read tools instead; they are faster, safer, and don't require shell permissions

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -26,6 +26,8 @@ Creates a PR with context, squash-merges, closes the linked issue, exports the s
 - NEVER use bash heredoc (`cat > file << 'EOF'`) for content with `#`-prefixed lines — headers trigger Claude Code's security check on every execution; use the Write tool instead
 - NEVER use `echo >` or `cat` to write file content — use the Write tool; it avoids shell escaping issues and doesn't trigger permission checks
 - NEVER use `find`, `grep`, or `cat` as Bash commands — use Glob, Grep, and Read tools instead; they are faster, safer, and don't require shell permissions
+- NEVER use interactive flags (`-i`, `-p`) in git commands (`git rebase -i`, `git add -p`, `git stash -p`) — Claude Code's non-interactive shell hangs waiting for input that never arrives
+- NEVER run `git commit` without `-m` — git spawns `$EDITOR` and waits; the agent cannot interact with it and the session hangs indefinitely
 
 ## Workflow
 

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -102,7 +102,7 @@ Create the PR:
 gh pr create --title "<issue title or branch description>" --body-file .weld/tmp/pr-body.md --base main
 ```
 
-Read the PR URL from the output (e.g. `https://github.com/owner/repo/pull/7`). Extract the PR number from the URL. Write the full PR URL to `.weld/tmp/pr-url.txt` and just the PR number to `.weld/tmp/pr-number.txt` with the Write tool.
+Read the PR URL from the output (e.g. `https://github.com/owner/repo/pull/7`). If no URL is present in the output, surface the error: "PR creation may have failed — no URL in output. Verify with `gh pr list --state open` before proceeding." and stop. Extract the PR number from the URL. Write the full PR URL to `.weld/tmp/pr-url.txt` and just the PR number to `.weld/tmp/pr-number.txt` with the Write tool.
 
 Clean up:
 ```bash


### PR DESCRIPTION
## Summary

Adds a consistent `---\n*Created with [gh-weld]*` attribution footer to all output produced by gh-weld-issue (issue bodies), gh-weld-ship (PR bodies), gh-weld-export (session comments), and gh-weld-adopt (issue bodies). Also applies a judge + HITL quality pass on gh-weld-ship and gh-weld-issue, hardening NEVER lists and error handling.

## Changes

- **Attribution footer**: all four skills now append `---\n*Created with [gh-weld](https://github.com/WrathZA/github-weld)*` to their output templates
- **gh-weld-ship NEVER list**: added `--no-verify`, backtick substitution, interactive git flags (`-i`, `-p`), and `git commit` without `-m` rules
- **gh-weld-ship Step 3**: added synthesis judgment criteria (meaningful change bullets, minimal test plan definition)
- **gh-weld-ship Step 4**: added guard for missing PR URL in `gh pr create` output
- **gh-weld-ship description**: added "squash merge" and "close issue" trigger keywords
- **gh-weld-issue NEVER list**: added full bash safety rules (&&, pipe, $(), heredoc, echo>, find/grep/cat) matching gh-weld-ship coverage
- **gh-weld-issue Step 10**: added `(r)etry / (Q)uit?` error handling for `gh issue create` failure
- **gh-weld-issue Step 8**: added graceful fallback when `gh label list` fails or returns empty
- **gh-weld-issue Phase 1**: trimmed activation content in step 2; strengthened WHY on create-while-implementing NEVER

## Test plan

- [ ] Create an issue with gh-weld-issue — verify attribution footer appears in the issue body on GitHub
- [ ] Ship a PR with gh-weld-ship — verify attribution footer appears in the PR body
- [ ] Export a session with gh-weld-export — verify attribution footer appears in the posted comment

## Issue

Closes #31

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
