### PR TITLE
Add gh-activity skill: repo and GitHub-wide activity digest

### DIFF
--- a/.weld/conventions.md
+++ b/.weld/conventions.md
@@ -44,6 +44,10 @@ rm .weld/tmp/<name>.md
 
 Use external tools (`python3`, `jq`, `curl`) only when no built-in equivalent exists.
 
+## Skill UX
+
+**Use single-keypress prompts for user choices** — when a skill needs the user to pick between options, present lettered choices (e.g. `Scope: (r)epo or (g)ithub-wide? [r]`) with a sensible default on Enter. Never design CLI-style flags for skill workflows.
+
 ## Git workflow
 
 **NEVER commit directly to `main` or `master`** — create a branch first, every time, without exception.

--- a/gh-activity/SKILL.md
+++ b/gh-activity/SKILL.md
@@ -14,10 +14,18 @@ Activity digest grouped by recency. Fetch, bucket, render.
   **Instead:** Show a `None` placeholder under Issues and PRs.
   **Why:** Omitting windows makes the digest look misleading — the user can't tell if nothing happened or the window was skipped.
 
-- **NEVER use `|`, `&&`, `$()`, or `;` in Bash calls**
-  **Instead:** Run each command as a separate Bash tool call; read JSON output directly from the tool result.
-  **Why:** Claude Code's permission system interrupts the session on pipes and command substitution.
-  Note: `|` in markdown table row syntax (as in the Bucket table above) is unaffected.
+- **NEVER use `|` (pipe) in Bash calls**
+  **Instead:** Read JSON output directly from the tool result — no piping needed in this skill.
+  **Why:** Claude Code stops execution when it encounters a pipe, interrupting the session without warning.
+  Note: `|` in markdown table row syntax is unaffected.
+
+- **NEVER chain Bash calls with `&&` or `;`**
+  **Instead:** Run each command as a separate Bash tool call.
+  **Why:** Claude Code's safety check fires on ambiguous multi-command calls and interrupts mid-flow.
+
+- **NEVER use `$()` command substitution**
+  **Instead:** Read command output directly from the Bash tool result.
+  **Why:** Claude Code's permission system prompts on `$()` during execution, interrupting unnecessarily.
 
 - **NEVER mix items across windows**
   **Instead:** Each item appears in exactly one window — the most recent it qualifies for.

--- a/gh-activity/SKILL.md
+++ b/gh-activity/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: gh-activity
+description: "GitHub activity digest — lists issues and PRs grouped by time window (today, last 3 days, last 7 days, last 30 days). Supports repo-scoped or GitHub-wide views, selected by single keypress. Use when: the user wants a repo overview, activity summary, recent activity digest, or to see what's changed. Trigger phrases: \"what's been happening\", \"activity digest\", \"repo overview\", \"recent activity\", \"what's new\"."
+compatibility: Requires gh CLI authenticated (gh auth login). Designed for Claude Code.
+---
+
+# gh-activity
+
+Activity digest grouped by recency. Fetch, bucket, render.
+
+## NEVER
+
+- **NEVER omit a time window because it has no activity**
+  **Instead:** Show a `None` placeholder under Issues and PRs.
+  **Why:** Omitting windows makes the digest look misleading — the user can't tell if nothing happened or the window was skipped.
+
+- **NEVER use `|`, `&&`, `$()`, or `;` in Bash calls**
+  **Instead:** Run each command as a separate Bash tool call; read JSON output directly from the tool result.
+  **Why:** Claude Code's permission system interrupts the session on pipes and command substitution.
+  Note: `|` in markdown table row syntax (as in the Bucket table above) is unaffected.
+
+- **NEVER mix items across windows**
+  **Instead:** Each item appears in exactly one window — the most recent it qualifies for.
+  **Why:** Overlapping windows inflate counts and confuse the user about what's actually new.
+
+## Workflow
+
+### 1 — Scope
+
+Ask: `Scope: (r)epo or (g)ithub-wide? [r]`
+
+- `r` or Enter → current repo only
+- `g` → all repos visible to the authenticated user
+
+### 2 — Fetch
+
+**Repo scope:**
+
+```bash
+gh issue list --state all --limit 200 --json number,title,state,author,url,createdAt
+```
+
+```bash
+gh pr list --state all --limit 200 --json number,title,state,author,url,createdAt
+```
+
+**GitHub-wide scope:**
+
+```bash
+gh search issues --limit 200 --sort created --json number,title,state,author,url,createdAt,repository
+```
+
+```bash
+gh search prs --limit 200 --sort created --json number,title,state,author,url,createdAt,repository
+```
+
+Read the JSON from each tool result directly — no temp files needed.
+
+> Discussions are not supported by the `gh` CLI JSON output; omit silently.
+
+### 3 — Bucket
+
+Get today's date (UTC). Classify each item into exactly one window:
+
+| Window | Item's `createdAt` is on or after… |
+|--------|-------------------------------------|
+| Today | today 00:00 UTC |
+| Last 3 days | today − 2 days 00:00 UTC |
+| Last 7 days | today − 6 days 00:00 UTC |
+| Last 30 days | today − 29 days 00:00 UTC |
+
+Assign to the most recent qualifying window. Items older than 30 days are omitted.
+
+### 4 — Render
+
+```
+## Today
+### Issues
+- #42 Fix login crash [open] — @alice — https://github.com/...
+### Pull Requests
+- #43 Add dark mode [merged] — @bob — https://github.com/...
+
+## Last 3 days
+### Issues
+None
+### Pull Requests
+- #41 Bump deps [closed] — @carol — https://github.com/...
+
+## Last 7 days
+...
+
+## Last 30 days
+...
+```
+
+For **GitHub-wide scope**, prefix each item with the repo: `owner/repo#42 Title [state] — @author — url`.
+
+Show item counts per window as a header suffix: `## Today (3 issues, 1 PR)`.

--- a/gh-activity/SKILL.md
+++ b/gh-activity/SKILL.md
@@ -40,6 +40,8 @@ Ask: `Scope: (r)epo or (g)ithub-wide? [r]`
 - `r` or Enter → current repo only
 - `g` → all repos visible to the authenticated user
 
+If the response is neither `r`, `g`, nor Enter: re-prompt once, then default to repo scope.
+
 ### 2 — Pre-flight
 
 ```bash

--- a/gh-activity/SKILL.md
+++ b/gh-activity/SKILL.md
@@ -80,7 +80,7 @@ gh search issues --limit 200 --sort created --json number,title,state,author,url
 gh search prs --limit 200 --sort created --json number,title,state,author,url,createdAt,repository
 ```
 
-Read the JSON from each tool result directly — no temp files needed.
+Read the JSON from each tool result directly — no temp files needed. The `author` field is an object: use `author.login` for the display name.
 
 > Discussions are not supported by the `gh` CLI JSON output; omit silently.
 

--- a/gh-activity/SKILL.md
+++ b/gh-activity/SKILL.md
@@ -32,7 +32,23 @@ Ask: `Scope: (r)epo or (g)ithub-wide? [r]`
 - `r` or Enter → current repo only
 - `g` → all repos visible to the authenticated user
 
-### 2 — Fetch
+### 2 — Pre-flight
+
+```bash
+gh auth status
+```
+
+If this fails: output "gh is not authenticated — run `gh auth login` first." and stop.
+
+Check gh version:
+
+```bash
+gh --version
+```
+
+`gh search` requires gh v2.29+. If the version is older and the user chose GitHub-wide scope, warn: "gh search requires v2.29 or later — falling back to repo scope." and proceed as repo scope.
+
+### 3 — Fetch
 
 **Repo scope:**
 
@@ -58,7 +74,7 @@ Read the JSON from each tool result directly — no temp files needed.
 
 > Discussions are not supported by the `gh` CLI JSON output; omit silently.
 
-### 3 — Bucket
+### 4 — Bucket
 
 Get today's date (UTC). Classify each item into exactly one window:
 
@@ -71,7 +87,7 @@ Get today's date (UTC). Classify each item into exactly one window:
 
 Assign to the most recent qualifying window. Items older than 30 days are omitted.
 
-### 4 — Render
+### 5 — Render
 
 ```
 ## Today


### PR DESCRIPTION
## Summary

Adds the `gh-activity` skill — a GitHub activity digest that lists issues and PRs grouped by time window (today, last 3 days, last 7 days, last 30 days). Supports both repo-scoped and GitHub-wide views selected via a single-keypress prompt. Also encodes the single-keypress UX convention into `.weld/conventions.md` so all future skills follow the same pattern.

## Changes

- `gh-activity/SKILL.md`: new skill with pre-flight auth/version check, per-construct bash NEVER rules, precise bucketing table, and None placeholders for empty windows
- `.weld/conventions.md`: new "Skill UX" section — single-keypress prompts over CLI flags

## Test plan

- [ ] Run `/gh-activity`, respond `r` — verify digest appears with all four time windows (empty windows show "None")
- [ ] Run `/gh-activity`, respond `g` — verify GitHub-wide results are prefixed with `owner/repo#N`
- [ ] Run on a repo where `gh` is not authenticated — verify skill stops with a clear error

## Issue

Closes #8

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
