### PR TITLE
Improve CLAUDE.md skill-forge guidance and symlink discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Reusable GitHub workflow skills for Claude Code. Provides `gh-weld-issue`, `gh-w
 
 @.weld/conventions.md
 
-## skill-forge-* operations
+## skill-forge-* operations — **Critical: skills created outside this repo are lost to git**
 
 **ALWAYS write new skill directories into this repo, never into `~/.claude/skills/` directly.** A skill created under `~/.claude/` is invisible to git and will never reach users — it exists only on your machine and is effectively lost.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,21 @@
 Reusable GitHub workflow skills for Claude Code. Provides `gh-weld-issue`, `gh-weld-next`, `gh-weld-ship`, `gh-weld-export`, and `gh-weld-adopt` — a complete issue-to-merge loop using the `gh` CLI.
 
 @.weld/conventions.md
+
+## skill-forge-* operations
+
+**ALWAYS write new skill directories into this repo, never into `~/.claude/skills/` directly.** A skill created under `~/.claude/` is invisible to git and will never reach users — it exists only on your machine and is effectively lost.
+
+When `skill-forge-create` or `write-a-skill` asks where to create the skill, provide a path inside this repo (e.g. `gh-weld-newskill/` at the repo root — never an absolute path with a hardcoded home dir).
+
+For all other `skill-forge-*` operations (`skill-forge-update`, `skill-forge-judge`, `skill-forge-recap`, etc.), always target the `SKILL.md` inside this repo — not the symlinked copy under `~/.claude/skills/`.
+
+## Adding a new skill
+
+After creating a new skill directory with a `SKILL.md` in this repo, run the symlink script so the skill is available globally:
+
+```
+bash symlink-global-skills.sh
+```
+
+This links the new skill dir into `~/.claude/skills/`. The script is idempotent — safe to re-run at any time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,4 +22,6 @@ After creating a new skill directory with a `SKILL.md` in this repo, run the sym
 bash symlink-global-skills.sh
 ```
 
+Run from the repo root.
+
 This links the new skill dir into `~/.claude/skills/`. The script is idempotent — safe to re-run at any time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ Reusable GitHub workflow skills for Claude Code. Provides `gh-weld-issue`, `gh-w
 
 When `skill-forge-create` or `write-a-skill` asks where to create the skill, provide a path inside this repo (e.g. `gh-weld-newskill/` at the repo root — never an absolute path with a hardcoded home dir). If the tool does not prompt for a location, explicitly instruct it before it begins: "Write the skill to `gh-weld-<name>/` at the repo root."
 
+Always create the skill on a branch, not on main — see conventions.md.
+
 For all other `skill-forge-*` operations (`skill-forge-update`, `skill-forge-judge`, `skill-forge-recap`, etc.), always target the `SKILL.md` inside this repo — not the symlinked copy under `~/.claude/skills/`.
 
 ## Adding a new skill

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Reusable GitHub workflow skills for Claude Code. Provides `gh-weld-issue`, `gh-w
 
 **ALWAYS write new skill directories into this repo, never into `~/.claude/skills/` directly.** A skill created under `~/.claude/` is invisible to git and will never reach users — it exists only on your machine and is effectively lost.
 
-When `skill-forge-create` or `write-a-skill` asks where to create the skill, provide a path inside this repo (e.g. `gh-weld-newskill/` at the repo root — never an absolute path with a hardcoded home dir).
+When `skill-forge-create` or `write-a-skill` asks where to create the skill, provide a path inside this repo (e.g. `gh-weld-newskill/` at the repo root — never an absolute path with a hardcoded home dir). If the tool does not prompt for a location, explicitly instruct it before it begins: "Write the skill to `gh-weld-<name>/` at the repo root."
 
 For all other `skill-forge-*` operations (`skill-forge-update`, `skill-forge-judge`, `skill-forge-recap`, etc.), always target the `SKILL.md` inside this repo — not the symlinked copy under `~/.claude/skills/`.
 


### PR DESCRIPTION
## Summary

Fixes CLAUDE.md to prevent skills from being silently created outside the repo. Adds skill-forge-* guidance, a fallback for when creation tools don't prompt for a path, branch discipline, and the required symlink step after adding any new skill.

## Changes

- Added `## skill-forge-* operations` section with a critical data-loss warning — skills written to `~/.claude/` are invisible to git and never reach users
- Added fallback instruction for when `skill-forge-create`/`write-a-skill` doesn't prompt for a path
- Added branch discipline note — new skills must be created on a branch, not main
- Added `## Adding a new skill` section documenting the `symlink-global-skills.sh` step from the repo root
- Replaced hardcoded user home path example with a portable repo-root-relative form

## Test plan

- [ ] Read CLAUDE.md and verify skill-forge-* section clearly states skills must be written to the repo, not `~/.claude/`

## Issue

Closes #35

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
