### PR TITLE
Add ## Done summary block to gh-weld-ship on completion

### DIFF
--- a/gh-weld-export/SKILL.md
+++ b/gh-weld-export/SKILL.md
@@ -82,7 +82,12 @@ Export the current session and post it to a GitHub PR or issue as a structured c
 
 9. Clean up:
    ```bash
-   rm .weld/tmp/session-export.md .weld/tmp/gist-url.txt .weld/tmp/export-comment.md .weld/tmp/export-summary.md
+   rm .weld/tmp/session-export.md .weld/tmp/export-comment.md .weld/tmp/export-summary.md
+   ```
+
+   If invoked by another skill (caller mode), **do not delete `.weld/tmp/gist-url.txt`** — leave it for the caller to read and remove. If invoked standalone, also remove it:
+   ```bash
+   rm .weld/tmp/gist-url.txt
    ```
 
 ## NEVER

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -193,14 +193,12 @@ rm .weld/tmp/pr-number.txt
 
 Invoke `/gh-weld-export` with the PR number as context. This exports the session transcript, uploads it as a secret Gist, and posts a structured summary comment on the merged PR.
 
-If `/gh-weld-export` fails, warn: "Session export failed — ship is otherwise complete." and continue to the completion output.
-
-Read `.weld/tmp/gist-url.txt` with the Read tool to get the Gist URL (written by `/gh-weld-export` in caller mode). Clean up:
+If `/gh-weld-export` succeeds: read `.weld/tmp/gist-url.txt` with the Read tool to get the Gist URL. Clean up:
 ```bash
 rm .weld/tmp/gist-url.txt
 ```
 
-If `.weld/tmp/gist-url.txt` does not exist (export failed), `<gist-url>` is unavailable — omit the Session line from the Done block.
+If `/gh-weld-export` fails: warn "Session export failed — ship is otherwise complete." Set `<gist-url>` unavailable and omit the Session line from the Done block. Proceed to the pr-url read below.
 
 Read `.weld/tmp/pr-url.txt` with the Read tool to get the PR URL. Clean up:
 ```bash

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -200,10 +200,16 @@ Read `.weld/tmp/pr-url.txt` with the Read tool to get the PR URL. Clean up:
 rm .weld/tmp/pr-url.txt
 ```
 
-Output:
-```
-Shipped: <issue title>
+Output a `## Done` block:
 
-PR:    <pr-url>
-Issue: https://github.com/<owner>/<repo>/issues/<N> (closed)
 ```
+## Done
+
+<One sentence: what was shipped and why, inferred from PR title and issue title.>
+
+- PR: <pr-url>
+- Issue: https://github.com/<owner>/<repo>/issues/<N> (closed)
+- Session: <gist-url>
+```
+
+If no linked issue, omit the Issue line. If export failed, omit the Session line.

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -7,10 +7,6 @@ when_to_use: "Use when done implementing, ready to ship, want to merge and close
 
 # gh-weld-ship
 
-You wrote the code. gh-weld-ship ships it.
-
-Creates a PR with context, squash-merges, closes the linked issue, exports the session to a Gist, and posts it on the PR.
-
 ## NEVER
 
 - NEVER create a PR from main — `gh pr create` will succeed but target the wrong base, shipping unreleased work directly; create a feature branch first

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -195,6 +195,13 @@ Invoke `/gh-weld-export` with the PR number as context. This exports the session
 
 If `/gh-weld-export` fails, warn: "Session export failed — ship is otherwise complete." and continue to the completion output.
 
+Read `.weld/tmp/gist-url.txt` with the Read tool to get the Gist URL (written by `/gh-weld-export` in caller mode). Clean up:
+```bash
+rm .weld/tmp/gist-url.txt
+```
+
+If `.weld/tmp/gist-url.txt` does not exist (export failed), `<gist-url>` is unavailable — omit the Session line from the Done block.
+
 Read `.weld/tmp/pr-url.txt` with the Read tool to get the PR URL. Clean up:
 ```bash
 rm .weld/tmp/pr-url.txt

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -220,3 +220,5 @@ Output a `## Done` block:
 ```
 
 If no linked issue, omit the Issue line. If export failed, omit the Session line.
+
+All steps complete. No further action required.

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -17,7 +17,7 @@ Creates a PR with context, squash-merges, closes the linked issue, exports the s
 - NEVER pass a PR body with `#`-prefixed lines as an inline `--body` argument — write to `.weld/tmp/pr-body.md` and pass via `--body-file`
 - NEVER merge before confirming the PR was created successfully — a failed `gh pr create` still exits 0 in some cases; verify the URL is present in the output before calling `gh pr merge`
 - NEVER close the issue before the merge is confirmed
-- NEVER skip the Gist export — the session context on the PR is the audit trail
+- NEVER skip the Gist export — the session context on the PR is the audit trail; if `/gh-weld-export` is unavailable, note its absence explicitly in the Done block rather than silently omitting it
 - NEVER prompt the user during issue enrichment — derive checkboxes and close-out narrative from the Step 3 synthesis automatically; any prompt here breaks the single-keypress ship flow
 - NEVER chain Bash commands with `&&` or `;` — Claude Code's safety check fires on multi-command calls and interrupts mid-flow; run each as a separate Bash tool call
 - NEVER use `|` (pipe) in Bash tool calls — Claude Code stops execution on pipe; redirect to a temp file with `>` and read back with the Read tool. Note: `|` in markdown table syntax is unaffected.


### PR DESCRIPTION
## Summary

Replaces the minimal "Shipped:" output at the end of `gh-weld-ship` with a structured `## Done` block containing a one-sentence summary, PR URL, issue URL, and Gist URL — giving the user an unambiguous signal that all steps are complete with every relevant link in one place.

## Changes

- `gh-weld-ship`: replace final output with `## Done` block (PR URL, issue URL, Gist URL, one-sentence summary)
- `gh-weld-ship`: capture Gist URL from `/gh-weld-export` via `.weld/tmp/gist-url.txt` after export completes
- `gh-weld-ship`: fix Step 7 export-fail branching so a failed export doesn't attempt to read a non-existent file
- `gh-weld-ship`: add INSTEAD path to "NEVER skip the Gist export" rule; trim intro paragraph that duplicated the description
- `gh-weld-export`: in caller mode, leave `gist-url.txt` for the calling skill to read and remove

## Test plan

- [ ] Run `/gh-weld-ship` on a feature branch — confirm the final output is a `## Done` block with PR, issue, and session links

## Issue

Closes #12

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
