### PR TITLE
Add marketplace-style installation support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,60 @@
+{
+  "name": "github-weld",
+  "owner": {
+    "name": "WrathZA",
+    "email": "WrathZA@users.noreply.github.com"
+  },
+  "metadata": {
+    "description": "Complete issue-to-merge workflow skills for GitHub-integrated development. Install all skills — they form a single loop."
+  },
+  "plugins": [
+    {
+      "name": "gh-weld-issue",
+      "description": "Create a structured GitHub issue via guided interview: duplicate check, acceptance criteria, label discovery, and blocker inference.",
+      "category": "github",
+      "source": "./gh-weld-issue",
+      "homepage": "https://github.com/WrathZA/github-weld",
+      "skills": ["./"]
+    },
+    {
+      "name": "gh-weld-next",
+      "description": "Pick an open issue, check for blockers, create a correctly-named branch, and hand off to implementation.",
+      "category": "github",
+      "source": "./gh-weld-next",
+      "homepage": "https://github.com/WrathZA/github-weld",
+      "skills": ["./"]
+    },
+    {
+      "name": "gh-weld-ship",
+      "description": "Wrap finished work in a PR, squash-merge, close the linked issue, and export the session as a Gist attached to the merge commit.",
+      "category": "github",
+      "source": "./gh-weld-ship",
+      "homepage": "https://github.com/WrathZA/github-weld",
+      "skills": ["./"]
+    },
+    {
+      "name": "gh-weld-export",
+      "description": "Export the Claude Code session as a markdown transcript and post it as a structured Gist comment on any PR or issue.",
+      "category": "github",
+      "source": "./gh-weld-export",
+      "homepage": "https://github.com/WrathZA/github-weld",
+      "skills": ["./"]
+    },
+    {
+      "name": "gh-weld-adopt",
+      "description": "Retroactively formalize ad-hoc work: create a structured issue, rename the branch to match, commit loose changes, and export the session.",
+      "category": "github",
+      "source": "./gh-weld-adopt",
+      "homepage": "https://github.com/WrathZA/github-weld",
+      "skills": ["./"]
+    },
+    {
+      "name": "gh-weld-activity",
+      "description": "GitHub activity digest — lists issues and PRs grouped by time window (today, last 3 days, last 7 days, last 30 days).",
+      "category": "github",
+      "source": "./gh-weld-activity",
+      "homepage": "https://github.com/WrathZA/github-weld",
+      "skills": ["./"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,21 @@ The payoff compounds. Run this loop and each issue becomes a structured artifact
 
 ## Installation
 
-Clone the repo and run the symlink script:
+The skills form a single loop — install all of them. A partial install leaves the workflow broken at the step you skipped.
+
+**Via Claude Code plugin marketplace** (no clone required):
+
+```
+/plugin marketplace add WrathZA/github-weld
+/plugin install gh-weld-issue
+/plugin install gh-weld-next
+/plugin install gh-weld-ship
+/plugin install gh-weld-export
+/plugin install gh-weld-adopt
+/plugin install gh-weld-activity
+```
+
+**Via symlink script** (for local development or if you prefer cloning):
 
 ```bash
 git clone https://github.com/WrathZA/github-weld
@@ -36,9 +50,7 @@ cd github-weld
 bash symlink-global-skills.sh
 ```
 
-This symlinks each skill directory into `~/.claude/skills/`, making them available in any project.
-
-To update, pull and re-run the script. Existing symlinks are left in place.
+This symlinks each skill directory into `~/.claude/skills/`, making them available in any project. To update, pull and re-run the script — existing symlinks are left in place.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` so all six gh-weld skills can be installed via `/plugin marketplace add WrathZA/github-weld` without cloning the repo. The README Installation section now leads with the marketplace flow, opens with a warning that all skills must be installed as a suite, and preserves the symlink method for local development.

## Changes

- Added `.claude-plugin/marketplace.json` defining all six skills with descriptions, category, and source paths — mirrors the skill-forge marketplace pattern exactly
- Updated README Installation section to lead with the plugin marketplace method, emphasize suite installation (partial installs break the workflow), and consolidate the symlink method as the local dev alternative

## Test plan

- [ ] Run `/plugin marketplace add WrathZA/github-weld` followed by `/plugin install gh-weld-ship` in a fresh Claude Code session and verify the skill is available

## Issue

Closes #11

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
