### PR TITLE
gh-weld-next: add (a)ccept/(r)evise/(s)kip prompt with issue comment on revise

### DIFF
--- a/gh-weld-next/SKILL.md
+++ b/gh-weld-next/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-weld-next
-description: "Pick an open GitHub issue to work on, then create a branch and hand off to the user. Lists open issues, lets you select one, reads the full issue details, creates a branch, and confirms you're ready to implement. Pair with /gh-weld-ship when work is done. Use when: starting a new piece of work, picking the next issue from the backlog, or creating a branch for an issue."
+description: "Pick an open GitHub issue to work on, then create a branch and hand off to the user. Lists open issues, lets you select one, reads the full issue details, optionally adds context notes posted as an issue comment, creates a branch, and confirms you're ready to implement. Pair with /gh-weld-ship when work is done. Use when: starting a new piece of work, picking the next issue from the backlog, adding notes or context to an issue before branching, or annotating an issue with decisions before starting work."
 ---
 
 # gh-weld-next

--- a/gh-weld-next/SKILL.md
+++ b/gh-weld-next/SKILL.md
@@ -66,6 +66,8 @@ gh issue view <blocker-N> --json number,title,state
 
 If any blocker is still open: warn "Issue #N is blocked by open issue #<blocker> — <title>. Work on it anyway? (y/n)". If no, return to step 3.
 
+Ask: "(a)ccept, (r)evise, or (s)kip?"
+
 ### 4 — Create branch
 
 Infer a branch name from the issue title: lowercase, hyphens, max 50 chars. Prefix with `fix/` for bugs, `feat/` for features, `chore/` for chores — inferred from labels. If type is ambiguous, use no prefix.

--- a/gh-weld-next/SKILL.md
+++ b/gh-weld-next/SKILL.md
@@ -10,7 +10,7 @@ Find something to work on. Read it. Branch. Go.
 ## NEVER
 
 - NEVER pick a blocked issue (one whose blocker issues are still open) without warning the user — starting blocked work wastes the sprint and may require a branch rename when the blocker resolves
-- NEVER create a branch from main if main has uncommitted changes — check first
+- NEVER create a branch from main if main has uncommitted changes — uncommitted changes contaminate the new branch and pollute the issue diff. Instead: commit or stash first.
 
 ## Workflow
 

--- a/gh-weld-next/SKILL.md
+++ b/gh-weld-next/SKILL.md
@@ -9,7 +9,7 @@ Find something to work on. Read it. Branch. Go.
 
 ## NEVER
 
-- NEVER pick a blocked issue (one whose blocker issues are still open) without warning the user
+- NEVER pick a blocked issue (one whose blocker issues are still open) without warning the user — starting blocked work wastes the sprint and may require a branch rename when the blocker resolves
 - NEVER create a branch from main if main has uncommitted changes — check first
 
 ## Workflow

--- a/gh-weld-next/SKILL.md
+++ b/gh-weld-next/SKILL.md
@@ -69,7 +69,7 @@ If any blocker is still open: warn "Issue #N is blocked by open issue #<blocker>
 Ask: "(a)ccept, (r)evise, or (s)kip?"
 
 - **(a)**: proceed to step 4.
-- **(r)**: prompt "Add context or notes (end with a blank line):". Collect the user's input. Write it to `.weld/tmp/comment-body.md` via Write tool. Post with:
+- **(r)**: prompt "Add context or notes (send as a single message):". Good notes: scope changes, key decisions, ambiguity resolved. Skip: restating the issue body. Collect the user's input. Write it to `.weld/tmp/comment-body.md` via Write tool. Post with:
   ```bash
   gh issue comment <N> --body-file .weld/tmp/comment-body.md
   ```

--- a/gh-weld-next/SKILL.md
+++ b/gh-weld-next/SKILL.md
@@ -74,6 +74,7 @@ Ask: "(a)ccept, (r)evise, or (s)kip?"
   gh issue comment <N> --body-file .weld/tmp/comment-body.md
   ```
   Delete with `rm .weld/tmp/comment-body.md`. Proceed to step 4.
+- **(s)**: return to "Which issue?" prompt in step 3.
 
 ### 4 — Create branch
 

--- a/gh-weld-next/SKILL.md
+++ b/gh-weld-next/SKILL.md
@@ -68,6 +68,12 @@ If any blocker is still open: warn "Issue #N is blocked by open issue #<blocker>
 
 Ask: "(a)ccept, (r)evise, or (s)kip?"
 
+- **(r)**: prompt "Add context or notes (end with a blank line):". Collect the user's input. Write it to `.weld/tmp/comment-body.md` via Write tool. Post with:
+  ```bash
+  gh issue comment <N> --body-file .weld/tmp/comment-body.md
+  ```
+  Delete with `rm .weld/tmp/comment-body.md`. Proceed to step 4.
+
 ### 4 — Create branch
 
 Infer a branch name from the issue title: lowercase, hyphens, max 50 chars. Prefix with `fix/` for bugs, `feat/` for features, `chore/` for chores — inferred from labels. If type is ambiguous, use no prefix.

--- a/gh-weld-next/SKILL.md
+++ b/gh-weld-next/SKILL.md
@@ -68,6 +68,7 @@ If any blocker is still open: warn "Issue #N is blocked by open issue #<blocker>
 
 Ask: "(a)ccept, (r)evise, or (s)kip?"
 
+- **(a)**: proceed to step 4.
 - **(r)**: prompt "Add context or notes (end with a blank line):". Collect the user's input. Write it to `.weld/tmp/comment-body.md` via Write tool. Post with:
   ```bash
   gh issue comment <N> --body-file .weld/tmp/comment-body.md


### PR DESCRIPTION
## Summary

Adds an `(a)ccept / (r)evise / (s)kip` prompt to `gh-weld-next` after displaying an issue. The `(r)` path collects free-text context notes from the user and posts them as a GitHub issue comment before proceeding to branch creation.

## Changes

- Added `(a)ccept / (r)evise / (s)kip` prompt at end of Step 3, replacing the implicit accept
- Added `(r)evise` branch — collects user notes, writes to `.weld/tmp/comment-body.md`, posts via `gh issue comment`, then proceeds to branch
- Added `(a)ccept` branch — proceeds directly to Step 4 (existing behaviour, now explicit)
- Added `(s)kip` branch — returns user to the issue picker in Step 3
- Updated skill description to include new keywords (context, notes, annotate, issue comment) for discoverability
- Added WHY and INSTEAD guidance to NEVER rules for blocked issues and uncommitted changes
- Added context-note guidance: what makes a useful note vs. restating the issue body
- Clarified end-of-input UX: "send your notes as a single message" instead of "end with a blank line"

## Test plan

- [ ] Run `/gh-weld-next`, pick an issue, choose `(r)`, enter notes — verify a comment appears on the issue and branch is created

## Issue

Closes #37

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
