### PR TITLE
Extend gh-weld-init to auto-create git repo and manage .gitignore

### DIFF
--- a/gh-weld-init/SKILL.md
+++ b/gh-weld-init/SKILL.md
@@ -116,6 +116,10 @@ Derive all conventions from the recap. Translate recap answers into voice and co
 
 Include: 1–2 sentences of project purpose, coding philosophy derived from tone and seriousness, and any scope boundaries the agent should respect. Do not include technology-specific guidance — that's out of scope for this skill.
 
+**`.gitignore`** — after writing both files, ensure `settings.local.json` is excluded from git.
+
+Use Glob to check if `.gitignore` exists in the current directory. If it does not exist, create it via the Write tool with `settings.local.json` as the first entry. If it exists, read it and append `settings.local.json` on a new line only if it is not already present.
+
 ---
 
 ## Phase 5 — Wire gh-weld

--- a/gh-weld-init/SKILL.md
+++ b/gh-weld-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-weld-init
-description: Scaffold a new project's README.md and CLAUDE.md via a guided abstract interview, then wire in gh-weld. Use when starting a new repo or when a project lacks CLAUDE.md or README. Trigger phrases: "init this project", "scaffold", "set up this repo", "create README", "new project setup", "initialize", "CLAUDE.md conventions".
+description: Scaffold a new project's README.md and CLAUDE.md via a guided abstract interview, then wire in gh-weld. Initializes a git repo if one doesn't exist and sets up .gitignore. Use when starting a new repo or when a project lacks CLAUDE.md or README. Trigger phrases: "init this project", "scaffold", "set up this repo", "create README", "new project setup", "initialize", "CLAUDE.md conventions", "new repository", "set up as a new git project".
 compatibility: Requires git and gh CLI. Designed for Claude Code with gh-weld installed.
 ---
 

--- a/gh-weld-init/SKILL.md
+++ b/gh-weld-init/SKILL.md
@@ -116,7 +116,7 @@ Derive all conventions from the recap. Translate recap answers into voice and co
 
 Include: 1–2 sentences of project purpose, coding philosophy derived from tone and seriousness, and any scope boundaries the agent should respect. Do not include technology-specific guidance — that's out of scope for this skill.
 
-**`.gitignore`** — after writing both files, ensure `settings.local.json` is excluded from git.
+**`.gitignore`** — after writing both files, ensure `settings.local.json` is excluded from git. This file contains user-local Claude Code config (path overrides, local permissions) that is machine-specific and must not be committed to shared repos.
 
 Use Glob to check if `.gitignore` exists in the current directory. If it does not exist, create it via the Write tool with `settings.local.json` as the first entry. If it exists, read it and append `settings.local.json` on a new line only if it is not already present.
 

--- a/gh-weld-init/SKILL.md
+++ b/gh-weld-init/SKILL.md
@@ -38,7 +38,7 @@ First, verify the current directory is a git repo:
 git rev-parse --is-inside-work-tree
 ```
 
-If the command fails or returns anything other than `true`: output "gh-weld-init requires a git repository. Run `git init` first." and stop.
+If the command fails or returns anything other than `true`: run `git init` as a separate Bash call to initialize a new repository, then continue.
 
 Use Glob to check for existing files:
 

--- a/gh-weld-init/SKILL.md
+++ b/gh-weld-init/SKILL.md
@@ -36,6 +36,8 @@ compatibility: Requires git and gh CLI. Designed for Claude Code with gh-weld in
 
 ## Phase 1 — Idempotency Check
 
+The primary risk here is overwriting in-progress work — read existing content before asking the user to commit to any change.
+
 First, verify the current directory is a git repo:
 
 ```bash

--- a/gh-weld-init/SKILL.md
+++ b/gh-weld-init/SKILL.md
@@ -28,6 +28,10 @@ compatibility: Requires git and gh CLI. Designed for Claude Code with gh-weld in
   **Instead:** Write only sections directly implied by the interview recap.
   **Why:** A README with five generic headings and placeholder text is worse than a short honest one.
 
+- **NEVER use the Write tool on an existing `.gitignore`**
+  **Instead:** Read it first, check for the entry, then append only if missing.
+  **Why:** Write overwrites the entire file, silently destroying existing ignore rules.
+
 ---
 
 ## Phase 1 — Idempotency Check


### PR DESCRIPTION
## Summary

Extends `gh-weld-init` to work in truly new projects: it now runs `git init` automatically when the directory isn't a git repo (instead of stopping with an error), and ensures `settings.local.json` is added to `.gitignore` after Phase 4 before any commit can happen. Four additional quality improvements from skill-forge-judge (grade B, 98/120) were also applied.

## Changes

- **Auto-init git repo**: Phase 1 now runs `git init` when `git rev-parse` fails, allowing the skill to bootstrap a project from scratch
- **`.gitignore` management**: Phase 4 creates or appends to `.gitignore` to exclude `settings.local.json` (user-local Claude Code config that must not be committed)
- **NEVER rule for `.gitignore` overwrite**: prevents the Write tool from silently destroying existing ignore rules when the file already exists
- **Phase 1 thinking framework**: adds a risk-framing sentence ("primary risk is overwriting in-progress work") before the procedural git-check
- **Description updated**: adds "initializes git repo", "new repository", and "set up as a new git project" keywords so the skill activates for new-project requests

## Test plan

- [ ] Invoke `/gh-weld-init` in a directory with no `.git` folder — confirm `git init` runs and the skill continues to Phase 2
- [ ] Complete the interview and accept — confirm `.gitignore` is created (or updated) with `settings.local.json`

## Issue

Closes #50

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
