### PR TITLE
Add daily automated CalVer release via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Daily CalVer Release
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — print tag without creating release'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest release tag
+        id: latest
+        run: |
+          TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check for new commits
+        id: check
+        run: |
+          if [ -z "${{ steps.latest.outputs.tag }}" ]; then
+            echo "No previous release found — treating as new commits"
+            echo "new_commits=true" >> $GITHUB_OUTPUT
+          else
+            COUNT=$(git rev-list ${{ steps.latest.outputs.tag }}..HEAD --count)
+            echo "Commits since ${{ steps.latest.outputs.tag }}: $COUNT"
+            if [ "$COUNT" -gt "0" ]; then
+              echo "new_commits=true" >> $GITHUB_OUTPUT
+            else
+              echo "new_commits=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Skip — no new commits
+        if: steps.check.outputs.new_commits == 'false'
+        run: echo "No new commits since ${{ steps.latest.outputs.tag }} — skipping release."
+
+      - name: Check today's tag
+        id: today
+        if: steps.check.outputs.new_commits == 'true'
+        run: |
+          TAG=$(date -u +%Y.%m.%d)
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          if [ -n "$(git tag -l "$TAG")" ]; then
+            echo "Tag $TAG already exists — skipping."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Dry run
+        if: steps.check.outputs.new_commits == 'true' && steps.today.outputs.exists == 'false' && inputs.dry_run == 'true'
+        run: echo "Would create release ${{ steps.today.outputs.tag }}"
+
+      - name: Create release
+        if: steps.check.outputs.new_commits == 'true' && steps.today.outputs.exists == 'false' && inputs.dry_run != 'true'
+        run: gh release create ${{ steps.today.outputs.tag }} --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs daily at midnight UTC, checks whether any commits exist since the last release, and creates a CalVer-tagged release with auto-generated notes if new commits are present.

## Changes

- `.github/workflows/release.yml` — new workflow with daily cron trigger (`0 0 * * *`), commit detection via `git rev-list`, same-day duplicate guard, `workflow_dispatch` with a `dry_run` input for safe manual testing, and `gh release create --generate-notes`

## Test plan

- [ ] Go to Actions → "Daily CalVer Release" → "Run workflow" with `dry_run` checked; confirm the log prints "Would create release YYYY.MM.DD"
- [ ] Trigger again with `dry_run` unchecked; verify a release appears on the Releases page with auto-generated notes
- [ ] Trigger when the latest release tag matches HEAD; confirm the job logs "No new commits — skipping" and exits 0

## Issue

Closes #55

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
