### PR TITLE
gh-weld-issue: add optional cross-repo filing

### DIFF
--- a/gh-weld-issue/SKILL.md
+++ b/gh-weld-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-weld-issue
-description: "Create a GitHub issue via guided interview. Checks for duplicates before creation (c/u/d resolution: continue as new, use existing and stop, or drop). Collects title and type; constructs structured body from scope, acceptance criteria, and blockers. Infers blockers from open issues. Discovers and applies repo labels. Enforces verifiable acceptance criteria (each must name a command, visible change, or measurable value). Creates via gh CLI using --body-file. One issue per outcome — never batches multiple ideas. Challenges misplaced issues with an assertive repo-fit warning before creation. Use when: filing a bug, planning a feature, capturing a task, or creating any GitHub issue. Skip if you are about to implement the work in this session — use gh-weld-ship instead."
+description: "Create a GitHub issue via guided interview. Optionally targets a different repo (cross-repo filing). Checks for duplicates before creation (c/u/d resolution: continue as new, use existing and stop, or drop). Collects title and type; constructs structured body from scope, acceptance criteria, and blockers. Infers blockers from open issues. Discovers and applies repo labels. Enforces verifiable acceptance criteria (each must name a command, visible change, or measurable value). Creates via gh CLI using --body-file. One issue per outcome — never batches multiple ideas. Challenges misplaced issues with an assertive repo-fit warning before creation. Use when: filing a bug, planning a feature, capturing a task, or creating any GitHub issue. Skip if you are about to implement the work in this session — use gh-weld-ship instead."
 ---
 
 # gh-weld-issue
@@ -23,11 +23,18 @@ Create a new GitHub issue through a brief HITL interview.
 
 ## Workflow
 
+### Phase 0 — Target repo
+
+Ask: "Target repo? Enter `owner/name` to file into a different repo, or `n` for the current one. [n]"
+
+- If the user provides an `owner/name` value (e.g. `WrathZA/github-weld`): store it as the target repo and append `--repo <owner>/<name>` to every `gh` command for the rest of this skill. Skip the repo-fit check in Phase 1 step 2 — the user has already chosen the destination.
+- If `n` or blank: use the current repo. No `--repo` flag is added.
+
 ### Phase 1 — Discover
 
 1. Ask: "What are you trying to build or fix?"
 
-2. **Repo-fit check** — read visible project signals:
+2. **Repo-fit check** (skip if a target repo was specified in Phase 0) — read visible project signals:
    ```bash
    gh repo view --json name,description
    ```

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -12,7 +12,7 @@ when_to_use: "Use when done implementing, ready to ship, want to merge and close
 - NEVER create a PR from main — `gh pr create` will succeed but target the wrong base, shipping unreleased work directly; create a feature branch first
 - NEVER pass a PR body with `#`-prefixed lines as an inline `--body` argument — write to `.weld/tmp/pr-body.md` and pass via `--body-file`
 - NEVER merge before confirming the PR was created successfully — a failed `gh pr create` still exits 0 in some cases; verify the URL is present in the output before calling `gh pr merge`
-- NEVER close the issue before the merge is confirmed
+- NEVER close the issue before the merge is confirmed — a failed merge leaves the issue orphaned as closed with no PR; reopening is manual
 - NEVER skip the Gist export — the session context on the PR is the audit trail; if `/gh-weld-export` is unavailable, note its absence explicitly in the Done block rather than silently omitting it
 - NEVER prompt the user during issue enrichment — derive checkboxes and close-out narrative from the Step 3 synthesis automatically; any prompt here breaks the single-keypress ship flow
 - NEVER chain Bash commands with `&&` or `;` — Claude Code's safety check fires on multi-command calls and interrupts mid-flow; run each as a separate Bash tool call

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -58,6 +58,8 @@ Read the commits on this branch since it diverged from main:
 git log main..HEAD --oneline
 ```
 
+If the output is empty (no commits on this branch), warn: "No commits found on this branch — commit your changes before shipping." and stop.
+
 Read the list of changed files:
 ```bash
 git diff main..HEAD --name-only

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -39,7 +39,7 @@ If the result is `main` or `master`: output "You're on main — /gh-weld-adopt c
 
 Try to infer the issue number from the branch name. Common patterns: `fix/42-slug`, `feat/42-slug`, `issue-42`, `42-slug`. Extract the number if present.
 
-If no number can be inferred, ask: "Which issue does this branch implement? Enter a number or (n)one."
+If no number can be inferred, output: "No issue number found — if this work isn't tracked yet, /gh-weld-adopt can create the issue and set up the branch before you ship." Then ask: "Which issue does this branch implement? Enter a number or (n)one."
 
 If an issue number is known, read it:
 ```bash

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-weld-ship
-description: "GitHub shipping loop — wraps your finished work in a PR, squash-merges it, closes the linked issue, exports the session as a Gist, and posts it as a comment. Enriches the linked issue before closing — updates acceptance criteria checkboxes and posts a close-out narrative comment automatically. Does not implement code; you do the work, gh-weld-ship handles everything GitHub. Use when you're ready to open a PR, squash merge, close an issue, or export session context."
+description: "GitHub shipping loop — wraps your finished work in a PR, squash-merges it, closes the linked issue, exports the session as a Gist, and posts it as a comment. Enriches the linked issue before closing — updates acceptance criteria checkboxes and posts a close-out narrative comment automatically. Does not implement code; you do the work, gh-weld-ship handles everything GitHub. Use when you're ready to open a PR, squash merge, close an issue, or ready to merge and close a finished feature branch."
 disable-model-invocation: true
 when_to_use: "Use when done implementing, ready to ship, want to merge and close an issue, or when the user says 'I'm done' on a feature branch."
 ---

--- a/gh-weld-ship/SKILL.md
+++ b/gh-weld-ship/SKILL.md
@@ -27,6 +27,8 @@ when_to_use: "Use when done implementing, ready to ship, want to merge and close
 
 ## Workflow
 
+Before proceeding, confirm mentally: (a) Is the diff what you expect — no stray files, no debug commits? (b) Do the commit messages accurately describe what was delivered? If either answer is no, stop and fix before continuing.
+
 ### 1 — Validate branch
 
 ```bash


### PR DESCRIPTION
## Summary

Adds an optional cross-repo filing step (Phase 0) to `gh-weld-issue`. When the user supplies an `owner/name` target, every `gh` command in the skill runs with `--repo <owner>/<name>` and the repo-fit check is skipped. When omitted (`n`), behaviour is unchanged.

## Changes

- Added Phase 0 prompt asking for a target repo before the interview — single-keypress `n` default (avoids the "press Enter" anti-pattern, which doesn't work in Claude Code's chat interface)
- Repo-fit check in Phase 1 step 2 skipped when a target repo is explicitly provided — user already chose the destination
- Updated skill description frontmatter to surface cross-repo filing capability

## Test plan

- [ ] Run `/gh-weld-issue` and enter `n` — workflow proceeds as before with no `--repo` flag
- [ ] Run `/gh-weld-issue` and enter a valid `owner/name` — all subsequent `gh` commands include `--repo owner/name` and the fit check is skipped

## Issue

Closes #60

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
