### PR TITLE
gh-weld-repo: infer repo description from README.md

### DIFF
--- a/gh-weld-repo/SKILL.md
+++ b/gh-weld-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-weld-repo
-description: Create a GitHub repo from a local directory via `gh repo create`. Inspects the current directory to infer repo name, language, topics, .gitignore template, and license — then interviews the user only for what it cannot infer, one question at a time. Shows a full confirm/edit/abort summary before acting. Pushes the local repo to the new remote on confirm. Use when: starting a project that needs a GitHub remote, pushing a local directory to GitHub for the first time. Triggers: "create a repo", "push to GitHub", "new GitHub repo", "initialize remote", "set up GitHub".
+description: Create a GitHub repo from a local directory via `gh repo create`. Inspects the current directory to infer repo name, language, topics, .gitignore template, license, and description (from README.md when present) — then interviews the user only for what it cannot infer, one question at a time. Shows a full confirm/edit/abort summary before acting. Pushes the local repo to the new remote on confirm. Use when: starting a project that needs a GitHub remote, pushing a local directory to GitHub for the first time. Triggers: "create a repo", "push to GitHub", "new GitHub repo", "initialize remote", "set up GitHub".
 compatibility: Requires git and gh CLI with authentication
 ---
 

--- a/gh-weld-repo/SKILL.md
+++ b/gh-weld-repo/SKILL.md
@@ -55,7 +55,7 @@ Infer the repo name from the current directory's folder name (`pwd`). Use Glob t
 
 If a `LICENSE` file exists, read the first line to infer the license identifier (e.g. `MIT`, `Apache-2.0`).
 
-Use Glob to check for `README.md`. If found, Read it and extract the first non-empty line of the first paragraph after any leading `#` heading, trimmed to ≤120 chars — this is the inferred description. If no `README.md` exists, check `CLAUDE.md` the same way. If neither exists (or no suitable text is found), the inferred description is blank. If the file contains only a heading with no body paragraph, or the extracted line is empty after stripping whitespace, also treat the inferred description as blank. Store this value for Phase 2.
+Use Glob to check for `README.md`. If found, Read it and extract the first non-empty line of the first paragraph after any leading `#` heading, trimmed to ≤120 chars — this is the inferred description. If no `README.md` exists, or the file contains only a heading with no body paragraph, or the extracted line is empty after stripping whitespace, the inferred description is blank. Store this value for Phase 2.
 
 If `git remote -v` shows `origin` is already configured: warn the user and ask `(c)ontinue anyway / (a)bort`. On abort, stop.
 

--- a/gh-weld-repo/SKILL.md
+++ b/gh-weld-repo/SKILL.md
@@ -55,7 +55,7 @@ Infer the repo name from the current directory's folder name (`pwd`). Use Glob t
 
 If a `LICENSE` file exists, read the first line to infer the license identifier (e.g. `MIT`, `Apache-2.0`).
 
-Use Glob to check for `README.md`. If found, Read it and extract the first non-empty line of the first paragraph after any leading `#` heading, trimmed to ≤120 chars — this is the inferred description. If no `README.md` exists, or the file contains only a heading with no body paragraph, or the extracted line is empty after stripping whitespace, the inferred description is blank. Store this value for Phase 2.
+Use Glob to check for `README.md`. If found, Read it and extract the first complete sentence from the first paragraph after any leading `#` heading (a sentence ends at `.`, `!`, or `?`) — this is the inferred description. If no sentence terminator is found, use the first line. If the result exceeds 120 characters, truncate at the nearest word boundary before the limit. If no `README.md` exists, or the file contains only a heading with no body paragraph, or the extracted text is empty after stripping whitespace, the inferred description is blank. Store this value for Phase 2.
 
 If `git remote -v` shows `origin` is already configured: warn the user and ask `(c)ontinue anyway / (a)bort`. On abort, stop.
 

--- a/gh-weld-repo/SKILL.md
+++ b/gh-weld-repo/SKILL.md
@@ -71,7 +71,7 @@ Ask only for settings still marked `(ask)`. Show inferred values first so the us
 
 **Order:**
 1. Visibility: "Public or private? [public]"
-2. Description: "One-line repo description?"
+2. Description: If an inferred description exists (from Phase 1), show `"Description: [<inferred>] — accept or enter a new one?"`. If blank, ask `"One-line repo description?"`.
 3. License (only if no LICENSE file found): "License? (e.g. MIT, Apache-2.0, none) [none]"
 4. Topics: "Suggested topics: `<detected stack>`. Accept, or enter your own?"
 5. Name (only if user wants to override): "Repo name? [<inferred>]"

--- a/gh-weld-repo/SKILL.md
+++ b/gh-weld-repo/SKILL.md
@@ -55,6 +55,8 @@ Infer the repo name from the current directory's folder name (`pwd`). Use Glob t
 
 If a `LICENSE` file exists, read the first line to infer the license identifier (e.g. `MIT`, `Apache-2.0`).
 
+Use Glob to check for `README.md`. If found, Read it and extract the first non-empty line of the first paragraph after any leading `#` heading, trimmed to ≤120 chars — this is the inferred description. If no `README.md` exists, check `CLAUDE.md` the same way. If neither exists (or no suitable text is found), the inferred description is blank. Store this value for Phase 2.
+
 If `git remote -v` shows `origin` is already configured: warn the user and ask `(c)ontinue anyway / (a)bort`. On abort, stop.
 
 Note whether `git status` reports "not a git repository" — needed in Phase 4.

--- a/gh-weld-repo/SKILL.md
+++ b/gh-weld-repo/SKILL.md
@@ -55,7 +55,7 @@ Infer the repo name from the current directory's folder name (`pwd`). Use Glob t
 
 If a `LICENSE` file exists, read the first line to infer the license identifier (e.g. `MIT`, `Apache-2.0`).
 
-Use Glob to check for `README.md`. If found, Read it and extract the first non-empty line of the first paragraph after any leading `#` heading, trimmed to ≤120 chars — this is the inferred description. If no `README.md` exists, check `CLAUDE.md` the same way. If neither exists (or no suitable text is found), the inferred description is blank. Store this value for Phase 2.
+Use Glob to check for `README.md`. If found, Read it and extract the first non-empty line of the first paragraph after any leading `#` heading, trimmed to ≤120 chars — this is the inferred description. If no `README.md` exists, check `CLAUDE.md` the same way. If neither exists (or no suitable text is found), the inferred description is blank. If the file contains only a heading with no body paragraph, or the extracted line is empty after stripping whitespace, also treat the inferred description as blank. Store this value for Phase 2.
 
 If `git remote -v` shows `origin` is already configured: warn the user and ask `(c)ontinue anyway / (a)bort`. On abort, stop.
 

--- a/gh-weld-repo/SKILL.md
+++ b/gh-weld-repo/SKILL.md
@@ -38,6 +38,10 @@ Create a GitHub repo from a local directory — infer what you can, ask for the 
   **Instead:** Use Glob to find files, Grep to search content, and Read to read files.
   **Why:** Built-in tools have tighter permissions and don't trigger Claude Code safety prompts the way raw shell commands can.
 
+- **NEVER use `mktemp` or `$(mktemp ...)`**
+  **Instead:** Use a fixed path under `.weld/tmp/` with the Write tool.
+  **Why:** `mktemp` uses platform-dependent `/tmp/` paths, and the `$()` substitution it requires triggers Claude Code permission prompts.
+
 ---
 
 ## Phase 1 — Inspect


### PR DESCRIPTION
## Summary

`gh-weld-repo` now infers a default repo description from `README.md` when one exists, extracting the first complete sentence from the first paragraph and pre-filling the Phase 2 prompt. The user can accept or override; when no README exists the question is asked as before.

## Changes

- Phase 1 uses Glob/Read to extract the first complete sentence from README.md's first paragraph (falls back to first line), word-boundary capped at 120 chars
- Phase 2 description prompt shows `[<inferred>]` as the default when extraction succeeds, plain prompt when blank
- CLAUDE.md fallback removed — CLAUDE.md holds agent instructions, not project descriptions, making it an unreliable source
- Explicit blank-fallback rule for heading-only READMEs or empty-after-strip results
- Frontmatter description updated to list description inference alongside other inferred fields
- New NEVER rule for `mktemp` (consistent with repo conventions)

## Test plan

- [ ] Run `/gh-weld-repo` in a project with a `README.md` — Phase 2 should show the inferred description as a pre-filled default
- [ ] Run in a project with no `README.md` — Phase 2 should ask `"One-line repo description?"` as before
- [ ] Run in a project where README has only a heading and no body — should fall through to asking as before

## Issue

Closes #59

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
