### PR TITLE
Add sandbox.md and .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .weld/tmp/
+sandbox.md
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds `sandbox.md` and `.claude/settings.local.json` to `.gitignore` so they no longer appear as untracked or modified files in `git status`. Both are local-only files that should never be committed.

## Changes

- `.gitignore`: added `sandbox.md` — local scratch file, not part of the repo
- `.gitignore`: added `.claude/settings.local.json` — local Claude Code settings, machine-specific

## Test plan

- [ ] `git status` shows no untracked `sandbox.md` or modified `.claude/settings.local.json` after this change

## Issue

Closes #64

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
