### PR TITLE
gh-weld-issue: add (e)xpand option to duplicate check

### DIFF
--- a/gh-weld-issue/SKILL.md
+++ b/gh-weld-issue/SKILL.md
@@ -63,10 +63,11 @@ A good issue has one outcome (one merge closes it) and criteria you can verify w
      Possible match(es):
        #N — Title [OPEN]
 
-     (c)ontinue as new, (u)se existing, (d)rop?
+     (c)ontinue as new, (u)se existing, (e)xpand existing, (d)rop?
      ```
      - **(c)** — proceed
      - **(u)** — output the issue URL and stop; `gh-weld-issue` creates issues, not edits them
+     - **(e)** — output the open issue's URL with the message: "Expand this issue's scope with your new requirements — use `gh issue edit` or the GitHub UI", then stop without creating a new issue. Only offered when at least one match is open; closed-only matches do not get `(e)`.
      - **(d)** — stop
    - If only closed matches: show them for context, offer `(c)ontinue / (d)rop`
    - If empty: proceed silently


### PR DESCRIPTION
## Summary

Adds `(e)xpand existing` as a fourth option in `gh-weld-issue`'s duplicate check when open matches are found. Selecting `(e)` outputs the open issue's URL with guidance to expand its scope via `gh issue edit` or the GitHub UI, then stops without creating a new issue. Closed-only matches are unchanged.

## Changes

- Extended the duplicate-check prompt in `gh-weld-issue/SKILL.md` to include `(e)xpand existing` for open matches, and documented that `(e)` is only offered when at least one match is open — closed-only matches keep the original `(c)/(d)` choice.

## Test plan

- [ ] Run `/gh-weld-issue` against an existing open duplicate; confirm the prompt reads `(c)ontinue as new, (u)se existing, (e)xpand existing, (d)rop?`, that `(e)` outputs the URL with the expand-scope message and stops, and that a closed-only match still only offers `(c)/(d)`.

## Issue

Closes #66

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
