### PR TITLE
gh-weld-issue: link related open issues after creation

### DIFF
--- a/gh-weld-issue/SKILL.md
+++ b/gh-weld-issue/SKILL.md
@@ -20,6 +20,8 @@ Create a new GitHub issue through a brief HITL interview.
 - NEVER use `echo >` or `cat` to write file content — use the Write tool; it shows content as a reviewable file-write in Claude Code's approval dialog, while echo and cat are invisible to the approval UI
 - NEVER use `find`, `grep`, or `cat` as Bash commands — use Glob, Grep, and Read tools instead; dedicated tools surface progress in the approval UI and integrate with Claude Code's permission model, while bash equivalents bypass both
 - NEVER warn on ambiguous repo fit — only surface the warning when the mismatch is clear and specific enough to name the other repo; false positives erode trust in the warning, and users warned repeatedly about non-issues will dismiss the next real one
+- NEVER include the newly created issue number in the Related comment — it's self-referential noise; always filter it from search results before formatting
+- NEVER surface the related-issue search to the user when no matches remain after filtering — the issue URL is the only post-creation signal; extra output dilutes it
 
 ## Workflow
 
@@ -126,7 +128,28 @@ A good issue has one outcome (one merge closes it) and criteria you can verify w
     ```
     If no matching labels exist, omit `--label`. If the command fails or produces no URL, surface the error and ask "(r)etry / (Q)uit?" — do not clean up until creation is confirmed.
 
-12. Clean up and output the issue URL:
+12. **Link related issues** — read the issue number from the URL `gh issue create` printed. Extract 2–4 topic keywords from the new issue's title (favor distinctive nouns and compound terms; skip common verbs like "add", "fix", "update"). Search open issues in the target repo:
+    ```bash
+    gh issue list --search "<keywords>" --state open --json number,title
+    ```
+    Filter out the newly created issue number. If no matches remain, skip the rest of this step silently — no comment, no output. If 1–5 matches remain, include all. If more than 5, keep the 5 closest by title similarity (shared topic words, similar phrasing).
+
+    Use the Write tool to write the comment body to `.weld/tmp/related-comment.md` as a single line:
+    ```
+    Related: #M (Title), #P (Title)
+    ```
+
+    Post the comment on the newly created issue:
+    ```bash
+    gh issue comment <N> --body-file .weld/tmp/related-comment.md
+    ```
+
+    Clean up:
+    ```bash
+    rm .weld/tmp/related-comment.md
+    ```
+
+13. Clean up and output the issue URL:
     ```bash
     rm .weld/tmp/issue-body.md
     ```


### PR DESCRIPTION
## Summary

After `gh issue create` succeeds in `gh-weld-issue`, the skill now searches the target repo for open issues that share keywords with the new title, filters out self-reference, caps results at 5 by title similarity, and posts a single-line `Related: #M (Title), #P (Title)` comment on the new issue. Skips silently when no matches remain.

## Changes

- Inserted step 12 in `gh-weld-issue` between issue creation and final cleanup — extracts 2–4 keywords from the new title, runs `gh issue list --search ... --state open`, filters out the newly created issue, caps at 5 closest by title similarity, and posts the Related comment via `--body-file`. Honors the cross-repo target from Phase 0.
- Renumbered the existing cleanup step from 12 to 13.
- Added two NEVER rules: forbid including the newly created issue in its own Related comment, and forbid surfacing the search to the user when no matches remain.

## Test plan

- [ ] Run `/gh-weld-issue` and create an issue whose title shares keywords with at least one open issue — confirm a `Related: #M (Title)` comment is posted on the new issue.
- [ ] Run `/gh-weld-issue` with a title that shares no keywords with any open issue — confirm no Related comment is posted and no extra output is shown after the URL.

## Issue

Closes #62

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
