### PR TITLE
gh-weld-repo: single-keypress license menu

### DIFF
--- a/gh-weld-repo/SKILL.md
+++ b/gh-weld-repo/SKILL.md
@@ -76,7 +76,20 @@ Ask only for settings still marked `(ask)`. Show inferred values first so the us
 **Order:**
 1. Visibility: "Public or private? [public]"
 2. Description: If an inferred description exists (from Phase 1), show `"Description: [<inferred>] — accept or enter a new one?"`. If blank, ask `"One-line repo description?"`.
-3. License (only if no LICENSE file found): "License? (e.g. MIT, Apache-2.0, none) [none]"
+3. License (only if no LICENSE file found): present a single-keypress menu:
+   ```
+   License? Single keypress:
+     (m) MIT
+     (a) Apache-2.0
+     (g) GPL-3.0
+     (b) BSD-3-Clause
+     (i) ISC
+     (p) MPL-2.0
+     (u) Unlicense
+     (n) none [default]
+   ```
+   Enter alone selects `none`. Map the keypress to the license identifier:
+   `m`→`MIT`, `a`→`Apache-2.0`, `g`→`GPL-3.0`, `b`→`BSD-3-Clause`, `i`→`ISC`, `p`→`MPL-2.0`, `u`→`Unlicense`, `n`/Enter→`none`. The selected identifier is passed to `gh repo create --license "<id>"` in Phase 4 (omit `--license` entirely when `none`).
 4. Topics: "Suggested topics: `<detected stack>`. Accept, or enter your own?"
 5. Name (only if user wants to override): "Repo name? [<inferred>]"
 


### PR DESCRIPTION
## Summary

Replaces the free-text license prompt in `gh-weld-repo` Phase 2 with a single-keypress lettered menu covering the major open-source licenses, matching the rest of the skill's UX.

## Changes

- `gh-weld-repo/SKILL.md` Phase 2 question #3: present an 8-option keypress menu (m/a/g/b/i/p/u/n) with explicit identifier mapping, so the user picks a license with one key instead of typing the SPDX string
- Default behavior preserved: Enter (or `n`) selects `none`, and `--license` is omitted from `gh repo create` in that case

## Test plan

- [ ] Run `gh-weld-repo` in a directory with no `LICENSE` file and confirm the lettered menu appears at question #3
- [ ] Press `m` → repo is created with `--license "MIT"`
- [ ] Press Enter → repo is created without a `--license` flag

## Issue

Closes #54

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
