### PR TITLE
Fix gh-weld-repo temp path and gh-weld-setup frontmatter

### DIFF
--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -31,7 +31,7 @@ Create a GitHub repo from a local directory — infer what you can, ask for the 
   **Why:** Adding a duplicate remote fails with an error and leaves the repo in a broken state.
 
 - **NEVER pass a multiline body containing `#`-prefixed lines as an inline `gh` argument**
-  **Instead:** Write to a temp file (e.g. `.claude/tmp/repo-desc.md`) with the Write tool and pass via `--body-file`.
+  **Instead:** Write to a temp file (e.g. `.weld/tmp/repo-desc.md`) with the Write tool and pass via `--body-file`.
   **Why:** Headers in inline strings trigger an un-suppressible Claude Code permission prompt.
 
 - **NEVER use `find`, `grep`, or `cat` in Bash tool calls**

--- a/skills/gh-weld-setup/SKILL.md
+++ b/skills/gh-weld-setup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: gh-weld-setup
-description: Set up a new or existing project end-to-end: scaffold README.md and CLAUDE.md via a guided abstract interview, wire in gh-weld conventions, and optionally create a GitHub repo. Use when starting a new repo or onboarding an existing project to gh-weld.
-when_to_use: "set up this project", "init this repo", "scaffold", "new project setup", "install gh-weld", "wire up weld", "initialize", "create README", "CLAUDE.md conventions", "new repository".
+description: "Set up a new or existing project end-to-end — scaffold README.md and CLAUDE.md via a guided abstract (tech-agnostic) interview, wire in gh-weld conventions, ensure .gitignore entries, and optionally create a GitHub repo (delegates to gh-weld-repo). Idempotent: re-run to accept, refresh, or refine existing files. Replaces the separate gh-weld-install and gh-weld-init skills. Use when: starting a new repo, onboarding an existing project to gh-weld, scaffolding README/CLAUDE.md, or wiring conventions. Triggers: 'set up this project', 'init this repo', 'scaffold', 'new project setup', 'install gh-weld', 'wire up weld', 'initialize', 'create README', 'new repository'."
 compatibility: Requires git and gh CLI. Claude Code with WebFetch.
 ---
 


### PR DESCRIPTION
## Summary

Two small skill-hygiene fixes found while reviewing how `gh-weld-setup` and `gh-weld-repo` relate.

## Changes

- **`gh-weld-repo`** — temp body file path corrected from `.claude/tmp/repo-desc.md` to `.weld/tmp/repo-desc.md`, matching every other skill (and the gitignored temp dir)
- **`gh-weld-setup`** — frontmatter `description:` was an unquoted YAML scalar containing `end-to-end:` (colon-space), which broke parsing and made the skill registry display only the bare name. Quoted it, dropped the malformed `when_to_use:` list, and folded its triggers into the description. The registry now shows the real description.

## Test plan

- [ ] `grep -r ".claude/tmp" skills/gh-weld-repo/SKILL.md` returns nothing
- [ ] `gh-weld-setup`'s description renders in full in the skill list (not just `gh-weld-setup`)

## Issue

Closes #75

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
