### PR TITLE
Harden gh-weld-next with error handling and selection judgment

### DIFF
--- a/skills/gh-weld-next/SKILL.md
+++ b/skills/gh-weld-next/SKILL.md
@@ -16,25 +16,11 @@ Find something to work on. Read it. Branch. Go.
 
 ### 1 — Check working tree
 
-```bash
-git status --porcelain
-```
+Run `git status --porcelain`. If the tree is dirty: output "Working tree has uncommitted changes — commit or stash before starting new work." and stop. This loop always branches from a clean `main` (see the NEVER rule above), so any uncommitted change — on `main` or a feature branch — would be carried onto the new branch and pollute the issue diff.
 
-If dirty: output "Working tree has uncommitted changes — commit or stash before starting new work." and stop.
+Run `git branch --show-current`. If not on `main` or `master`: warn "You're on branch `<branch>` — switch to main before starting new work? (y/n)". On yes, run `git checkout main`.
 
-```bash
-git branch --show-current
-```
-
-If not on `main` or `master`: warn "You're on branch `<branch>` — switch to main before starting new work? (y/n)". If yes:
-```bash
-git checkout main
-```
-
-Pull latest:
-```bash
-git pull
-```
+Run `git pull` to get the latest. If the pull fails (diverged history or merge conflict): output "`git pull` failed — main has diverged. Resolve the conflict or reconcile manually before starting new work." and stop. Do not branch from an unmerged main.
 
 ### 2 — List open issues
 
@@ -49,6 +35,8 @@ If no open issues: output "No open issues. Run /gh-weld-issue to create one." an
 ### 3 — Pick
 
 Ask: "Which issue? Enter a number from the list, or describe what you want to work on."
+
+If the user is undecided, suggest the next issue by judgment, not just list order: prefer the highest-priority unblocked issue, break ties toward the one that unblocks the most other open issues, then toward the smallest well-scoped change that can ship this session. Surface the reason ("#N is unblocked and unblocks #X, #Y") rather than just naming it.
 
 If the user describes something: match against titles and confirm before proceeding. If no match, offer to run `/gh-weld-issue` first.
 
@@ -85,6 +73,8 @@ Show the proposed name and ask: "(a)ccept or enter a different name?"
 ```bash
 git checkout -b <branch-name>
 ```
+
+If the branch already exists (`fatal: a branch named '<branch-name>' already exists`): ask "Branch `<branch-name>` already exists — enter a different name, or (c)heck out the existing one?" Do not overwrite it.
 
 ### 5 — Hand off
 


### PR DESCRIPTION
## Summary

Applies the five skill-forge-judge improvements to `gh-weld-next` (was B, 104/120). Adds the failure-path handling the skill previously assumed away, reconciles an internal inconsistency between Step 1 and its NEVER rule, trims activation-level command ceremony, and turns issue selection from list-mechanics into judgment.

## Changes

- Step 1 now stops with a clear message when `git pull` fails (diverged history / conflict) instead of assuming success and branching from an unmerged main
- Step 4 detects an existing branch on `git checkout -b` and offers a rename / check-out choice instead of letting the command error out
- Step 1's dirty-tree stop is tied explicitly to the main-scoped NEVER rule, so it reads as intentional (the loop always branches from a clean main) rather than stricter than the rule it enforces
- Step 1's four basic git commands are inlined (no per-command fenced block), foregrounding the enforcement logic over well-known commands
- Step 3 gains a selection-judgment frame (priority → most-unblocking → smallest-shippable) for when the user is undecided

## Test plan

- [ ] Read `skills/gh-weld-next/SKILL.md` and confirm Step 1 handles `git pull` failure, Step 4 handles branch collision, and Step 3 includes the selection-judgment guidance

## Issue

Closes #77

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
