### PR TITLE
Fix Enter-default prompts and complete gh-weld-repo judge findings

### DIFF
--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -73,7 +73,9 @@ Note whether `git status` reports "not a git repository" — needed in Phase 4.
 
 ## Phase 2 — Interview
 
-Before asking questions: check whether the inferred repo name looks right at `github.com/<username>/<name>`. Generic names (`test`, `project`, `new`, `app`, `demo`) are red flags — flag the name as a suggestion to reconsider and move it to question #5.
+Before asking questions, think about what makes these settings good, not just valid: a repo name should be specific and searchable (someone scanning a repo list should guess what it does); a description should say what the project *is* and who it's for in one line, not restate the name; topics should be discovery terms others would actually search. Let that shape what you suggest and what you flag for reconsideration.
+
+Check whether the inferred repo name looks right at `github.com/<username>/<name>`. Generic names (`test`, `project`, `new`, `app`, `demo`) are red flags — flag the name as a suggestion to reconsider and move it to question #5.
 
 Ask only for settings still marked `(ask)`. Show inferred values first so the user can accept or override. One question at a time.
 
@@ -140,7 +142,7 @@ If the command fails:
 - Output contains "authentication" or "401" → tell the user to run `gh auth login` and retry
 - Any other error → surface the raw error output and stop
 
-If topics were collected, set them after creation:
+If topics were collected, set them after creation. The `gh repo create` output names the new repo as `<owner>/<name>` (e.g. "✓ Created repository alice/my-app on GitHub") and the repo URL is `https://github.com/<owner>/<name>` — take `<owner>/<name>` from there; do not guess the owner.
 ```bash
 gh repo edit <owner>/<name> --add-topic "<topic>"
 ```
@@ -153,7 +155,7 @@ If Phase 1 noted "not a git repository": run `git init`, then `git add -A`, then
 
 ### Add remote and push
 
-Read the repo URL from the `gh repo create` output. If no `origin` remote exists, run `git remote add origin <url>`. Push with `git push -u origin main`; if it fails because the default branch is `master`, retry with `git push -u origin master`.
+Read the repo URL from the `gh repo create` output. If no `origin` remote exists, run `git remote add origin <url>`. Determine the current branch with `git branch --show-current` and push that branch by name: `git push -u origin <current-branch>`. This handles `main`, `master`, or any other default branch name without guessing.
 
 ---
 

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -42,6 +42,10 @@ Create a GitHub repo from a local directory — infer what you can, ask for the 
   **Instead:** Use a fixed path under `.weld/tmp/` with the Write tool.
   **Why:** `mktemp` uses platform-dependent `/tmp/` paths, and the `$()` substitution it requires triggers Claude Code permission prompts.
 
+- **NEVER offer Enter (empty line) as the way to accept a default in a prompt**
+  **Instead:** Bind every default to an explicit keypress (e.g. `(n) none`, reply `k` to keep) — never `[default]`/"press Enter".
+  **Why:** Claude Code's CLI can't submit an empty line, so an Enter-default is unreachable and the user is stuck.
+
 ---
 
 ## Phase 1 — Inspect
@@ -74,7 +78,7 @@ Before asking questions: check whether the inferred repo name looks right at `gi
 Ask only for settings still marked `(ask)`. Show inferred values first so the user can accept or override. One question at a time.
 
 **Order:**
-1. Visibility: "Public or private? [public]"
+1. Visibility: "Public or private? Reply (p)ublic or pri(v)ate." Map `p`→public, `v`→private. Public is the recommended default — reply `p` to accept it. Do not rely on Enter; require a keypress.
 2. Description: If an inferred description exists (from Phase 1), show `"Description: [<inferred>] — accept or enter a new one?"`. If blank, ask `"One-line repo description?"`.
 3. License (only if no LICENSE file found): present a single-keypress menu:
    ```
@@ -86,12 +90,12 @@ Ask only for settings still marked `(ask)`. Show inferred values first so the us
      (i) ISC
      (p) MPL-2.0
      (u) Unlicense
-     (n) none [default]
+     (n) none
    ```
-   Enter alone selects `none`. Map the keypress to the license identifier:
-   `m`→`MIT`, `a`→`Apache-2.0`, `g`→`GPL-3.0`, `b`→`BSD-3-Clause`, `i`→`ISC`, `p`→`MPL-2.0`, `u`→`Unlicense`, `n`/Enter→`none`. The selected identifier is passed to `gh repo create --license "<id>"` in Phase 4 (omit `--license` entirely when `none`).
+   Press `n` for none (the recommended default) — do not rely on Enter, which the CLI can't submit. Map the keypress to the license identifier:
+   `m`→`MIT`, `a`→`Apache-2.0`, `g`→`GPL-3.0`, `b`→`BSD-3-Clause`, `i`→`ISC`, `p`→`MPL-2.0`, `u`→`Unlicense`, `n`→`none`. The selected identifier is passed to `gh repo create --license "<id>"` in Phase 4 (omit `--license` entirely when `none`).
 4. Topics: "Suggested topics: `<detected stack>`. Accept, or enter your own?"
-5. Name (only if user wants to override): "Repo name? [<inferred>]"
+5. Name (only if user wants to override): "Repo name? Reply `k` to keep `<inferred>`, or type a new name." Do not rely on Enter to accept the inferred name.
 
 ---
 


### PR DESCRIPTION
## Summary

Applies all five skill-forge-judge findings to `gh-weld-repo` (was B, 134/150). The headline fix: several interview defaults were selectable only via Enter, which Claude Code's CLI can't submit — making them unreachable. Also closes a few operational gaps (unbound `<owner>`, main↔master-only push) and adds a quality mindset frame.

## Changes

- **Enter-as-default removed**: Phase 2 visibility, license, and name prompts now bind their default to an explicit keypress; added a NEVER rule so the pattern can't return
- **`<owner>` sourced**: `gh repo edit` topic calls now take `<owner>/<name>` from the `gh repo create` output instead of an unbound placeholder
- **Push generalized**: pushes the actual current branch by name (`git branch --show-current`) instead of only falling back main→master
- **Mindset frame**: Phase 2 now opens with what makes a good repo name / description / topics, not just valid values

## Test plan

- [ ] Read `skills/gh-weld-repo/SKILL.md` and confirm: no `[default]`/Enter prompts in Phase 2, a NEVER rule against Enter-as-default, `<owner>` derived from create output, current-branch push, and the Phase 2 mindset frame

## Issue

Closes #81

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
