### PR TITLE
Enable model invocation for gh-weld-ship and drop redundant when_to_use

### DIFF
--- a/skills/gh-weld-ship/SKILL.md
+++ b/skills/gh-weld-ship/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: gh-weld-ship
 description: "GitHub shipping loop — wraps your finished work in a PR, squash-merges it, closes the linked issue, exports the session as a Gist, and posts it as a comment. Enriches the linked issue before closing — updates acceptance criteria checkboxes and posts a close-out narrative comment automatically. Does not implement code; you do the work, gh-weld-ship handles everything GitHub. Use when you're ready to open a PR, squash merge, close an issue, or ready to merge and close a finished feature branch."
-disable-model-invocation: true
-when_to_use: "Use when done implementing, ready to ship, want to merge and close an issue, or when the user says 'I'm done' on a feature branch."
 ---
 
 # gh-weld-ship


### PR DESCRIPTION
## Summary

Removes two frontmatter fields from the gh-weld-ship skill: `disable-model-invocation: true` (so the skill can be auto-discovered and invoked by the model like the other gh-weld skills) and the non-standard `when_to_use` field (redundant with `description`).

## Changes

- Drop `disable-model-invocation: true` from `skills/gh-weld-ship/SKILL.md` frontmatter — makes gh-weld-ship model-invocable, matching the rest of the gh-weld suite
- Drop the non-standard `when_to_use` field — its "use when" guidance already lives in the `description`, so it was duplicate metadata

## Test plan

- [ ] `skills/gh-weld-ship/SKILL.md` frontmatter contains neither `disable-model-invocation` nor `when_to_use`, and `description` is unchanged

## Issue

Closes #88

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
