### PR TITLE
fix: bootstrap scaffold on a branch so close-the-loop works (#84)

### DIFF
--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -47,7 +47,7 @@ Create a GitHub repo from a local directory — infer what you can, ask for the 
   **Why:** Claude Code's CLI can't submit an empty line, so an Enter-default is unreachable and the user is stuck.
 
 - **NEVER commit the scaffold straight to `main` on a fresh bootstrap**
-  **Instead:** Commit a minimal empty base to `main` (`git commit --allow-empty`), then create a branch and commit the scaffold there.
+  **Instead:** Keep gh's initial commit (the `--gitignore`/`--license` files) as the base on `main`, then create a branch and commit the scaffold there.
   **Why:** A scaffold landed directly on `main` bypasses branch → PR → merge review and leaves `gh-weld-adopt` nothing to formalize, dead-ending the close-the-loop chain (issue #84).
 
 ---
@@ -155,15 +155,21 @@ gh repo edit <owner>/<name> --add-topic "<topic>"
 
 One `gh repo edit` call per topic. If a call fails, log the error and continue — topic tagging is non-critical and should not block the push.
 
-### Initialize if needed
+### Initialize if needed — graft onto the remote base
 
-When Phase 1 noted "not a git repository", bootstrap on a branch: commit a minimal empty base to `main`, then put the scaffold on a branch. Run as separate Bash calls:
+When Phase 1 noted "not a git repository", the repo gh just created already carries a minimal base commit on `main` — the `--gitignore`/`--license` files form GitHub's initial commit. Use **that** as the base and stack the scaffold on a branch on top of it. Do **not** create a second local initial commit: pushing it would be rejected as unrelated history. Run as separate Bash calls:
 
 ```bash
 git init
 ```
 ```bash
-git commit --allow-empty -m "Initial commit"
+git remote add origin <url>
+```
+```bash
+git fetch origin
+```
+```bash
+git reset --mixed origin/main
 ```
 ```bash
 git branch -M main
@@ -178,24 +184,33 @@ git add -A
 git commit -m "Scaffold project files"
 ```
 
-If the repo already has commits, skip this entire block — the existing history is pushed as-is in the next step.
+`git reset --mixed origin/main` adopts gh's base commit as local `main` while leaving the scaffold files untouched in the working tree; the scaffold then lands as one commit on `setup/scaffold`. If the repo already has commits, skip this block — see "Existing history" below.
 
 ### Add remote and push
 
-Read the repo URL from the `gh repo create` output. If no `origin` remote exists, run `git remote add origin <url>`.
+Read the repo URL from the `gh repo create` output (used as `<url>` above).
 
-**Fresh bootstrap** (the Initialize block above ran): push the base first, then the scaffold branch — as separate Bash calls:
+**Fresh bootstrap** (the Initialize block above ran): the remote is already added and local `main` already matches gh's base commit — push only the scaffold branch:
 
-```bash
-git push -u origin main
-```
 ```bash
 git push -u origin setup/scaffold
 ```
 
-`main` becomes the default branch and the PR base; `setup/scaffold` carries the reviewable scaffold.
+`main` stays the default branch and PR base; `setup/scaffold` carries the reviewable scaffold.
 
-**Existing history** (Initialize block skipped): determine the current branch with `git branch --show-current` and push that branch by name: `git push -u origin <current-branch>`. This handles `main`, `master`, or any other default branch name without guessing.
+**Existing history** (Initialize block skipped): if no `origin` remote exists, run `git remote add origin <url>`. Because gh initialized the remote with a base commit, reconcile before pushing so the histories aren't unrelated:
+
+```bash
+git fetch origin
+```
+```bash
+git pull --rebase origin main
+```
+```bash
+git push -u origin <current-branch>
+```
+
+Determine `<current-branch>` with `git branch --show-current` (handles `main`, `master`, or any default without guessing). If the rebase reports conflicts, resolve them before pushing.
 
 ---
 

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -124,6 +124,8 @@ Ask: `(c)onfirm / (e)dit / (a)bort`
 
 ## Phase 4 — Create & Push
 
+> On a fresh repo, the scaffold goes on a branch, not straight to `main` — the first body of work must flow through branch → PR → merge like every other change. Committing it to `main` bypasses review and dead-ends `gh-weld-adopt` (see the NEVER rule, ref #84).
+
 ### Create the repo
 
 Run as separate Bash calls (no chaining):

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -220,8 +220,8 @@ Determine `<current-branch>` with `git branch --show-current` (handles `main`, `
 ```
 Repo created: <url>
 Remote:       origin → <url>
-Base:         main (empty initial commit) — PR base
-Scaffold:     setup/scaffold — your project files, ready to land via PR
+Base:         main — gh's initial commit (.gitignore/license), the PR base
+Scaffold:     setup/scaffold — your project files (provisional; /gh-weld-adopt renames it)
 
 Next: run /gh-weld-adopt → /gh-weld-ship to open a PR, squash-merge, and close.
 ```

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -151,7 +151,28 @@ One `gh repo edit` call per topic. If a call fails, log the error and continue â
 
 ### Initialize if needed
 
-If Phase 1 noted "not a git repository": run `git init`, then `git add -A`, then `git commit -m "Initial commit"`. If the repo already has commits, skip the add/commit.
+When Phase 1 noted "not a git repository", bootstrap on a branch: commit a minimal empty base to `main`, then put the scaffold on a branch. Run as separate Bash calls:
+
+```bash
+git init
+```
+```bash
+git commit --allow-empty -m "Initial commit"
+```
+```bash
+git branch -M main
+```
+```bash
+git checkout -b setup/scaffold
+```
+```bash
+git add -A
+```
+```bash
+git commit -m "Scaffold project files"
+```
+
+If the repo already has commits, skip this entire block â€” the existing history is pushed as-is in the next step.
 
 ### Add remote and push
 

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-weld-repo
-description: Create a GitHub repo from a local directory via `gh repo create`. Inspects the current directory to infer repo name, language, topics, .gitignore template, license, and description (from README.md when present) — then interviews the user only for what it cannot infer, one question at a time. Shows a full confirm/edit/abort summary before acting. Pushes the local repo to the new remote on confirm. Use when: starting a project that needs a GitHub remote, pushing a local directory to GitHub for the first time. Triggers: "create a repo", "push to GitHub", "new GitHub repo", "initialize remote", "set up GitHub".
+description: Create a GitHub repo from a local directory via `gh repo create`. Inspects the current directory to infer repo name, language, topics, .gitignore template, license, and description (from README.md when present) — then interviews the user only for what it cannot infer, one question at a time. Shows a full confirm/edit/abort summary before acting. Pushes the local repo to the new remote on confirm — on a fresh repo, bootstraps the scaffold on a branch (minimal empty base on `main`, scaffold on a branch) so the first work lands via PR. Use when: starting a project that needs a GitHub remote, pushing a local directory to GitHub for the first time. Triggers: "create a repo", "push to GitHub", "new GitHub repo", "initialize remote", "set up GitHub".
 compatibility: Requires git and gh CLI with authentication
 ---
 

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -176,7 +176,20 @@ If the repo already has commits, skip this entire block — the existing history
 
 ### Add remote and push
 
-Read the repo URL from the `gh repo create` output. If no `origin` remote exists, run `git remote add origin <url>`. Determine the current branch with `git branch --show-current` and push that branch by name: `git push -u origin <current-branch>`. This handles `main`, `master`, or any other default branch name without guessing.
+Read the repo URL from the `gh repo create` output. If no `origin` remote exists, run `git remote add origin <url>`.
+
+**Fresh bootstrap** (the Initialize block above ran): push the base first, then the scaffold branch — as separate Bash calls:
+
+```bash
+git push -u origin main
+```
+```bash
+git push -u origin setup/scaffold
+```
+
+`main` becomes the default branch and the PR base; `setup/scaffold` carries the reviewable scaffold.
+
+**Existing history** (Initialize block skipped): determine the current branch with `git branch --show-current` and push that branch by name: `git push -u origin <current-branch>`. This handles `main`, `master`, or any other default branch name without guessing.
 
 ---
 

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -46,6 +46,10 @@ Create a GitHub repo from a local directory — infer what you can, ask for the 
   **Instead:** Bind every default to an explicit keypress (e.g. `(n) none`, reply `k` to keep) — never `[default]`/"press Enter".
   **Why:** Claude Code's CLI can't submit an empty line, so an Enter-default is unreachable and the user is stuck.
 
+- **NEVER commit the scaffold straight to `main` on a fresh bootstrap**
+  **Instead:** Commit a minimal empty base to `main` (`git commit --allow-empty`), then create a branch and commit the scaffold there.
+  **Why:** A scaffold landed directly on `main` bypasses branch → PR → merge review and leaves `gh-weld-adopt` nothing to formalize, dead-ending the close-the-loop chain (issue #84).
+
 ---
 
 ## Phase 1 — Inspect

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-weld-repo
-description: Create a GitHub repo from a local directory via `gh repo create`. Inspects the current directory to infer repo name, language, topics, .gitignore template, license, and description (from README.md when present) — then interviews the user only for what it cannot infer, one question at a time. Shows a full confirm/edit/abort summary before acting. Pushes the local repo to the new remote on confirm — on a fresh repo, bootstraps the scaffold on a branch (minimal empty base on `main`, scaffold on a branch) so the first work lands via PR. Use when: starting a project that needs a GitHub remote, pushing a local directory to GitHub for the first time. Triggers: "create a repo", "push to GitHub", "new GitHub repo", "initialize remote", "set up GitHub".
+description: Create a GitHub repo from a local directory via `gh repo create`. Inspects the current directory to infer repo name, language, topics, .gitignore template, license, and description (from README.md when present) — then interviews the user only for what it cannot infer, one question at a time. Shows a full confirm/edit/abort summary before acting. Pushes the local repo to the new remote on confirm — on a fresh repo, bootstraps the scaffold on a branch so the first work lands via PR. Use when: starting a project that needs a GitHub remote, pushing a local directory to GitHub for the first time. Triggers: "create a repo", "push to GitHub", "new GitHub repo", "initialize remote", "set up GitHub".
 compatibility: Requires git and gh CLI with authentication
 ---
 

--- a/skills/gh-weld-repo/SKILL.md
+++ b/skills/gh-weld-repo/SKILL.md
@@ -195,7 +195,17 @@ git push -u origin setup/scaffold
 
 ## Phase 5 — Done
 
-Output:
+**Fresh bootstrap:**
+```
+Repo created: <url>
+Remote:       origin → <url>
+Base:         main (empty initial commit) — PR base
+Scaffold:     setup/scaffold — your project files, ready to land via PR
+
+Next: run /gh-weld-adopt → /gh-weld-ship to open a PR, squash-merge, and close.
+```
+
+**Existing history:**
 ```
 Repo created: <url>
 Remote:       origin → <url>


### PR DESCRIPTION
## Summary

Implements fix A from issue #84 in `gh-weld-repo`: on a fresh repo, the scaffold no longer lands directly on `main`. gh's own initial commit (from `--gitignore`/`--license`) becomes the PR base, and the scaffold is grafted onto a `setup/scaffold` branch — so the close-the-loop chain (`adopt → ship → export`) has real work to formalize instead of dead-ending at `gh-weld-adopt`.

## Changes

- **Phase 4 bootstrap reworked** — fresh repos now `git init` → add remote → `fetch` → `git reset --mixed origin/main` to adopt gh's base commit as `main`, then commit the scaffold on `setup/scaffold`. Avoids the unrelated-history rejection that the original "push a local empty `main`" flow would have hit, since `gh repo create --gitignore/--license` already initializes the remote.
- **Push flow split** — fresh bootstrap pushes only the scaffold branch (`main` already matches the remote); the existing-history path reconciles via `fetch` + `pull --rebase` before pushing.
- **Guardrail + rationale** — a new NEVER rule against committing the scaffold straight to `main`, plus a Phase 4 rationale line, both referencing #84.
- **Output + description** — Phase 5 "Done" reflects the two-branch state and marks `setup/scaffold` as provisional (adopt renames it); the frontmatter description notes bootstrap-on-a-branch.

## Test plan

- [ ] Run `/gh-weld-setup` in a fresh non-repo directory, accept repo creation, then choose "close the loop" — confirm it reaches a PR with no dead-end at `gh-weld-adopt`, and that `git push` is not rejected as unrelated history.

## Issue

Closes #84

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
